### PR TITLE
Extract generic Telegram bot framework to `tg-bot-worker` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ dependencies = [
 name = "hjcommon"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "env_logger",
@@ -904,6 +905,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
+ "tg-bot-worker",
  "tokio",
  "value2struct",
 ]
@@ -2669,6 +2671,19 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "tg-bot-worker"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "frankenstein",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace]
-members = ["native", "common", "dict", "worker", "web"]
+members = ["native", "common", "dict", "worker", "web", "tg-bot-worker"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,10 +13,12 @@ frankenstein = { workspace = true }
 rust-embed = { workspace = true }
 jsonwebtoken = { workspace = true }
 chrono = { workspace = true }
+async-trait = "0.1"
 subtle = "2"
 
 value2struct = { path = "../value2struct" }
 hjdict = { path = "../dict" }
+tg-bot-worker = { path = "../tg-bot-worker" }
 
 # test only
 tokio = { workspace = true }

--- a/common/src/tg.rs
+++ b/common/src/tg.rs
@@ -5,13 +5,14 @@ use core::fmt;
 use frankenstein::AsyncTelegramApi;
 use frankenstein::client_reqwest::Bot;
 use frankenstein::methods::{SendMessageParams, SetMyCommandsParams, SetWebhookParams};
-use frankenstein::types::{
-    ChatId, LinkPreviewOptions, MaybeInaccessibleMessage, MessageEntityType,
-};
-use frankenstein::updates::UpdateContent;
+use frankenstein::types::{ChatId, LinkPreviewOptions, MaybeInaccessibleMessage};
 use hjdict::{en, google, jp, kotobanku, kr, weblio};
 use log::*;
 use std::sync::Arc;
+use tg_bot_worker::utils::{
+    html_escape, markdown_escape, split_message, vec_string_markdown_escape,
+};
+use tg_bot_worker::{process_update, TelegramBot};
 
 #[derive(Debug)]
 pub enum Command {
@@ -98,44 +99,6 @@ pub fn bot_commands() -> Vec<frankenstein::types::BotCommand> {
     ]
 }
 
-pub fn split_message(text: &str, max_len: usize) -> Vec<String> {
-    let mut chunks = Vec::with_capacity(text.len() / max_len.max(1) + 1);
-    let mut start = 0;
-
-    for (idx, c) in text.char_indices() {
-        if idx - start + c.len_utf8() > max_len && idx > start {
-            chunks.push(text[start..idx].to_string());
-            start = idx;
-        }
-    }
-
-    if start < text.len() {
-        chunks.push(text[start..].to_string());
-    }
-
-    chunks
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_split_message() {
-        let text = "hello world";
-        let chunks = split_message(text, 5);
-        assert_eq!(chunks, vec!["hello", " worl", "d"]);
-
-        let text = "你好世界";
-        let chunks = split_message(text, 6);
-        assert_eq!(chunks, vec!["你好", "世界"]);
-
-        let text = "嗨";
-        let chunks = split_message(text, 2);
-        assert_eq!(chunks, vec!["嗨"]);
-    }
-}
-
 #[derive(Debug)]
 pub enum CallbackQueryCommand {
     Delete,
@@ -143,102 +106,61 @@ pub enum CallbackQueryCommand {
     Remove(String),
 }
 
-pub(super) const MARKDOWN_ESCAPE_CHARS: [char; 19] = [
-    '\\', '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
-];
+#[async_trait::async_trait(?Send)]
+impl<T, T2> TelegramBot for RunOpt<T, T2>
+where
+    T: DB + Clone,
+    T2: WorkersAI + Clone,
+{
+    type Error = Error;
 
-pub fn markdown_escape(s: &str) -> String {
-    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
-        if MARKDOWN_ESCAPE_CHARS.contains(&c) {
-            s.push('\\');
-        }
-        s.push(c);
-        s
-    })
-}
+    async fn handle_command(
+        &self,
+        msg: frankenstein::types::Message,
+        cmd: &str,
+        args: &str,
+    ) -> Result<(), Self::Error> {
+        let quote_or_reply_message = match msg.quote.as_ref() {
+            None => match msg.reply_to_message.as_ref() {
+                None => "",
+                Some(v) => match v.text.as_ref() {
+                    Some(v) => v,
+                    None => "",
+                },
+            },
+            Some(v) => v.text.as_ref(),
+        };
 
-pub fn html_escape(s: &str) -> String {
-    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
-        match c {
-            '&' => s.push_str("&amp;"),
-            '<' => s.push_str("&lt;"),
-            '>' => s.push_str("&gt;"),
-            c => s.push(c),
-        }
-        s
-    })
-}
-
-pub fn vec_string_markdown_escape(v: &Vec<String>) -> String {
-    let mut s = String::new();
-    for i in v {
-        s.push_str(markdown_escape(i.as_str()).as_str());
-        s.push_str("\n");
+        let (command_enum, _) = parse_command(cmd, args, quote_or_reply_message)?;
+        answer(Arc::new(self.clone()), Box::new(msg), command_enum)
+            .await
+            .map_err(|e| Error(e.to_string()))
     }
-    s
+
+    async fn handle_callback(
+        &self,
+        query: frankenstein::types::CallbackQuery,
+        cmd: &str,
+        args: &str,
+    ) -> Result<(), Self::Error> {
+        let (command_enum, _) = parse_callback_query_command(cmd, args)?;
+        callback_query(Arc::new(self.clone()), Box::new(query), command_enum)
+            .await
+            .map_err(|e| Error(e.to_string()))
+    }
 }
 
-pub async fn handle<T: DB, T2: WorkersAI>(
+pub async fn handle<T, T2>(
     opt: Arc<RunOpt<T, T2>>,
     update: frankenstein::updates::Update,
-) -> Result<(), Error> {
-    match update.content {
-        UpdateContent::Message(msg) | UpdateContent::EditedMessage(msg) => {
-            let entity = match msg.entities.as_ref() {
-                Some(v) if !v.is_empty() && v[0].type_field == MessageEntityType::BotCommand => {
-                    &v[0]
-                }
-                _ => return Err(Error("no command entity".to_string())),
-            };
-
-            let txt = match msg.text.as_ref() {
-                Some(v) => v,
-                None => return Err(Error("no text".to_string())),
-            };
-
-            let quote_or_reply_message = match msg.quote.as_ref() {
-                None => match msg.reply_to_message.as_ref() {
-                    None => "",
-                    Some(v) => match v.text.as_ref() {
-                        Some(v) => v,
-                        None => "",
-                    },
-                },
-                Some(v) => v.text.as_ref(),
-            };
-
-            let command =
-                &txt[entity.offset as usize..entity.offset as usize + entity.length as usize];
-
-            let argument = txt[entity.offset as usize + entity.length as usize..].trim();
-
-            let (cmd, text) = parse_command(command, argument, quote_or_reply_message)?;
-
-            info!("message command: {:?}, argument: {:?}", cmd, text);
-
-            answer(opt, msg, cmd).await?;
-        }
-        UpdateContent::CallbackQuery(msg) => {
-            let (command, argument) = match msg.data.as_ref() {
-                Some(v) => {
-                    let mut data = v.splitn(2, ' ');
-                    let command = data.next().unwrap_or("");
-                    let argument = data.next().unwrap_or("");
-                    (command.to_string(), argument.to_string())
-                }
-                None => return Err(Error("no data".to_string())),
-            };
-
-            let (cmd, text) = parse_callback_query_command(command.as_str(), argument.as_str())?;
-
-            info!("callback query command: {:?}, argument: {:?}", cmd, text);
-
-            callback_query(opt, msg, cmd).await?;
-        }
-        _ => return Err(Error("not message".to_string())),
-    };
-
-    Ok(())
+) -> Result<(), Error>
+where
+    T: DB + Clone,
+    T2: WorkersAI + Clone,
+{
+    process_update(&*opt, update)
+        .await
+        .map_err(|e| Error(e.to_string()))
 }
 
 #[derive(Debug)]

--- a/tg-bot-worker/Cargo.toml
+++ b/tg-bot-worker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tg-bot-worker"
+version = "0.1.0"
+edition = "2024"
+authors = ["Your Name <you@example.com>"]
+description = "A generic Telegram bot framework for Cloudflare Workers."
+license = "MIT"
+keywords = ["telegram", "bot", "worker", "framework"]
+categories = ["api-bindings", "web-programming"]
+repository = "https://github.com/your/repo"
+documentation = "https://docs.rs/tg-bot-worker"
+
+[dependencies]
+frankenstein = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+thiserror = "1.0"
+async-trait = "0.1"
+
+[dev-dependencies]
+tokio = { workspace = true }
+frankenstein = { workspace = true }
+serde_json = { workspace = true }

--- a/tg-bot-worker/README.md
+++ b/tg-bot-worker/README.md
@@ -1,0 +1,75 @@
+# tg-bot-worker
+
+A lightweight, generic framework for building Telegram bots, designed with Cloudflare Workers (and other WASM environments) in mind.
+
+It abstracts away the boilerplate of parsing updates, routing commands, and handling callbacks, while remaining agnostic to the underlying HTTP client or runtime.
+
+## Features
+
+- **Runtime Agnostic**: Works on Cloudflare Workers (`worker-rs`), native Rust, or any other environment.
+- **Async Trait**: Uses `async_trait` with `?Send` support, making it compatible with single-threaded runtimes like Cloudflare Workers.
+- **Command Parsing**: Automatically parses `/command arguments` from messages.
+- **Callback Queries**: Handles callback queries with a simple `cmd args` convention.
+- **Safe Utilities**: Includes helpers for safe UTF-16 string slicing (critical for correct Telegram entity offsets) and Markdown/HTML escaping.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+tg-bot-worker = "0.1"
+frankenstein = "0.46" # For types
+async-trait = "0.1"
+```
+
+## Usage
+
+Implement the `TelegramBot` trait for your bot struct:
+
+```rust
+use tg_bot_worker::{TelegramBot, process_update};
+use frankenstein::types::{Message, CallbackQuery, Update};
+use async_trait::async_trait;
+
+struct MyBot;
+
+#[async_trait(?Send)]
+impl TelegramBot for MyBot {
+    type Error = std::convert::Infallible;
+
+    async fn handle_command(&self, msg: Message, cmd: &str, args: &str) -> Result<(), Self::Error> {
+        println!("Received command: {} with args: {}", cmd, args);
+        // logic to send reply...
+        Ok(())
+    }
+
+    async fn handle_callback(&self, query: CallbackQuery, cmd: &str, args: &str) -> Result<(), Self::Error> {
+        println!("Received callback: {} with args: {}", cmd, args);
+        Ok(())
+    }
+
+    async fn handle_message(&self, msg: Message) -> Result<(), Self::Error> {
+        println!("Received plain message: {:?}", msg.text);
+        Ok(())
+    }
+}
+
+// In your request handler (e.g., worker fetch event):
+async fn handle_request(update: Update) {
+    let bot = MyBot;
+    process_update(&bot, update).await.unwrap();
+}
+```
+
+## Utilities
+
+The crate exports useful utilities in `tg_bot_worker::utils`:
+- `markdown_escape(s)`: Escape generic Markdown characters.
+- `html_escape(s)`: Escape HTML special characters.
+- `split_message(text, limit)`: Split long text into chunks (safe for UTF-8).
+- `get_utf16_slice(s, offset, length)`: Safe slicing using Telegram's UTF-16 offsets.
+
+## License
+
+MIT

--- a/tg-bot-worker/examples/simple_bot.rs
+++ b/tg-bot-worker/examples/simple_bot.rs
@@ -1,0 +1,72 @@
+use tg_bot_worker::{TelegramBot, process_update};
+use frankenstein::types::{Message, CallbackQuery};
+use frankenstein::updates::Update;
+use async_trait::async_trait;
+use std::convert::Infallible;
+
+struct MyBot;
+
+#[async_trait(?Send)]
+impl TelegramBot for MyBot {
+    type Error = Infallible;
+
+    async fn handle_command(&self, _msg: Message, cmd: &str, args: &str) -> Result<(), Self::Error> {
+        println!("Received command: {} with args: {}", cmd, args);
+        // In a real bot, you would send a reply using frankenstein::Bot
+        Ok(())
+    }
+
+    async fn handle_callback(&self, _query: CallbackQuery, cmd: &str, args: &str) -> Result<(), Self::Error> {
+        println!("Received callback: {} with args: {}", cmd, args);
+        Ok(())
+    }
+
+    async fn handle_message(&self, msg: Message) -> Result<(), Self::Error> {
+        if let Some(text) = msg.text {
+            println!("Received plain message: {}", text);
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let bot = MyBot;
+
+    // Simulate a command update using JSON
+    let json = r#"
+    {
+        "update_id": 1,
+        "message": {
+            "message_id": 123,
+            "date": 1600000000,
+            "chat": {
+                "id": 12345,
+                "type": "private",
+                "username": "user",
+                "first_name": "User"
+            },
+            "from": {
+                "id": 12345,
+                "is_bot": false,
+                "first_name": "User"
+            },
+            "text": "/hello world",
+            "entities": [
+                {
+                    "offset": 0,
+                    "length": 6,
+                    "type": "bot_command"
+                }
+            ]
+        }
+    }
+    "#;
+
+    // Use fully qualified path for serde_json which is a dev-dependency
+    let update: Update = serde_json::from_str(json).expect("Failed to parse JSON");
+
+    if let Err(e) = process_update(&bot, update).await {
+        println!("Error processing update: {:?}", e);
+    }
+}

--- a/tg-bot-worker/src/bot.rs
+++ b/tg-bot-worker/src/bot.rs
@@ -1,0 +1,63 @@
+use frankenstein::types::{CallbackQuery, Message, MessageEntityType};
+use frankenstein::updates::{Update, UpdateContent};
+use async_trait::async_trait;
+use log::info;
+use crate::utils::{get_utf16_slice, get_utf16_slice_rest};
+
+#[async_trait(?Send)]
+pub trait TelegramBot {
+    type Error: std::fmt::Debug;
+
+    async fn handle_command(&self, msg: Message, cmd: &str, args: &str) -> Result<(), Self::Error>;
+
+    async fn handle_callback(
+        &self,
+        query: CallbackQuery,
+        cmd: &str,
+        args: &str,
+    ) -> Result<(), Self::Error>;
+
+    async fn handle_message(&self, _msg: Message) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+pub async fn process_update<B: TelegramBot>(bot: &B, update: Update) -> Result<(), B::Error> {
+    match update.content {
+        UpdateContent::Message(msg) | UpdateContent::EditedMessage(msg) => {
+            let command_info = msg.entities.as_ref().and_then(|entities| {
+                entities
+                    .iter()
+                    .find(|e| e.type_field == MessageEntityType::BotCommand)
+                    .map(|e| (e.offset, e.length))
+            });
+
+            if let Some((offset, length)) = command_info {
+                let txt = msg.text.clone().unwrap_or_default();
+                let command = get_utf16_slice(&txt, offset as usize, length as usize);
+                let argument =
+                    get_utf16_slice_rest(&txt, offset as usize + length as usize)
+                        .trim()
+                        .to_string();
+
+                info!("message command: {:?}, argument: {:?}", command, argument);
+                bot.handle_command(*msg, &command, &argument).await
+            } else {
+                bot.handle_message(*msg).await
+            }
+        }
+        UpdateContent::CallbackQuery(query) => {
+            let data = query.data.clone().unwrap_or_default();
+            let mut parts = data.splitn(2, ' ');
+            let command = parts.next().unwrap_or("");
+            let argument = parts.next().unwrap_or("");
+
+            info!(
+                "callback query command: {:?}, argument: {:?}",
+                command, argument
+            );
+            bot.handle_callback(*query, command, argument).await
+        }
+        _ => Ok(()),
+    }
+}

--- a/tg-bot-worker/src/lib.rs
+++ b/tg-bot-worker/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod utils;
+pub mod bot;
+
+pub use bot::{TelegramBot, process_update};
+pub use utils::{split_message, markdown_escape, html_escape, vec_string_markdown_escape};
+pub use frankenstein;

--- a/tg-bot-worker/src/utils.rs
+++ b/tg-bot-worker/src/utils.rs
@@ -1,0 +1,108 @@
+pub const MARKDOWN_ESCAPE_CHARS: [char; 19] = [
+    '\\', '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!',
+];
+
+pub fn markdown_escape(s: &str) -> String {
+    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+        if MARKDOWN_ESCAPE_CHARS.contains(&c) {
+            s.push('\\');
+        }
+        s.push(c);
+        s
+    })
+}
+
+pub fn html_escape(s: &str) -> String {
+    s.chars().fold(String::with_capacity(s.len()), |mut s, c| {
+        match c {
+            '&' => s.push_str("&amp;"),
+            '<' => s.push_str("&lt;"),
+            '>' => s.push_str("&gt;"),
+            c => s.push(c),
+        }
+        s
+    })
+}
+
+pub fn vec_string_markdown_escape(v: &Vec<String>) -> String {
+    let mut s = String::new();
+    for i in v {
+        s.push_str(markdown_escape(i.as_str()).as_str());
+        s.push_str("\n");
+    }
+    s
+}
+
+pub fn split_message(text: &str, max_len: usize) -> Vec<String> {
+    let mut chunks = Vec::with_capacity(text.len() / max_len.max(1) + 1);
+    let mut start = 0;
+
+    for (idx, c) in text.char_indices() {
+        if idx - start + c.len_utf8() > max_len && idx > start {
+            chunks.push(text[start..idx].to_string());
+            start = idx;
+        }
+    }
+
+    if start < text.len() {
+        chunks.push(text[start..].to_string());
+    }
+
+    chunks
+}
+
+pub fn get_utf16_slice(s: &str, offset: usize, length: usize) -> String {
+    let wide: Vec<u16> = s.encode_utf16().collect();
+    if offset >= wide.len() {
+        return "".to_string();
+    }
+    let end = (offset + length).min(wide.len());
+    String::from_utf16_lossy(&wide[offset..end])
+}
+
+pub fn get_utf16_slice_rest(s: &str, offset: usize) -> String {
+    let wide: Vec<u16> = s.encode_utf16().collect();
+    if offset >= wide.len() {
+        return "".to_string();
+    }
+    String::from_utf16_lossy(&wide[offset..])
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_message() {
+        let text = "hello world";
+        let chunks = split_message(text, 5);
+        assert_eq!(chunks, vec!["hello", " worl", "d"]);
+
+        let text = "你好世界";
+        let chunks = split_message(text, 6);
+        assert_eq!(chunks, vec!["你好", "世界"]);
+
+        let text = "嗨";
+        let chunks = split_message(text, 2);
+        assert_eq!(chunks, vec!["嗨"]);
+    }
+
+    #[test]
+    fn test_utf16_slice() {
+        let text = "你好 world"; // 你(1) 好(1) ' '(1)
+        // utf16: 4f60 597d 0020 ...
+
+        let s = get_utf16_slice(text, 0, 1);
+        assert_eq!(s, "你");
+
+        let s = get_utf16_slice(text, 1, 1);
+        assert_eq!(s, "好");
+
+        let s = get_utf16_slice(text, 2, 5);
+        assert_eq!(s, " worl");
+
+        let s = get_utf16_slice_rest(text, 2);
+        assert_eq!(s, " world");
+    }
+}


### PR DESCRIPTION
Extracted the generic Telegram bot infrastructure from `common/src/tg.rs` into a new, reusable crate `tg-bot-worker`. This crate is designed to be runtime-agnostic and supports single-threaded environments like Cloudflare Workers via `#[async_trait(?Send)]`. It includes safe UTF-16 string slicing utilities for correct entity handling and Markdown/HTML escaping helpers. The existing `hjcommon` crate was refactored to use this new framework, simplifying the codebase and verifying the framework's usability.


---
*PR created automatically by Jules for task [3489978803328035685](https://jules.google.com/task/3489978803328035685) started by @Asutorufa*