### PR TITLE
Add CI lint check and auto-fix PR

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -8,6 +8,58 @@ on:
     branches: [ "rust" ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Create dummy web assets
+        run: mkdir -p web/out && touch web/out/index.html
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Run fmt check
+        run: cargo fmt --all --check
+
+      - name: Run clippy check
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Auto fix
+        if: failure() && github.event_name == 'push' && github.ref_name == 'rust'
+        run: |
+          cargo fmt --all
+          cargo clippy --fix --allow-dirty --all-targets --all-features -- -D warnings || true
+
+      - name: Create Pull Request
+        if: failure() && github.event_name == 'push' && github.ref_name == 'rust'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: fix linting issues"
+          title: "chore: fix linting issues"
+          body: |
+            Automated fix for linting issues.
+            - cargo fmt
+            - cargo clippy --fix
+          branch: lint-fix
+          base: rust
+          delete-branch: true
+
   web:
     runs-on: ubuntu-latest
     steps:

--- a/common/src/tg.rs
+++ b/common/src/tg.rs
@@ -573,7 +573,8 @@ pub async fn callback_query<T: DatabaseExecutor, T2: WorkersAI>(
                     word_type: 0,
                     example: "",
                 })
-                .await {
+                .await
+            {
                 error!("save word failed: {}", e);
                 return Ok(());
             }

--- a/worker/src/consolelog.rs
+++ b/worker/src/consolelog.rs
@@ -12,7 +12,9 @@ impl Log for WebConsoleLogger {
     }
 
     fn log(&self, record: &Record) {
-        if record.module_path().unwrap_or("") == "html5ever::serialize" { return }
+        if record.module_path().unwrap_or("") == "html5ever::serialize" {
+            return;
+        }
 
         if !self.enabled(record.metadata()) {
             return;


### PR DESCRIPTION
I have added a new `lint` job to the `.github/workflows/rust.yaml` file. This job performs the following:
1.  **Lint Check**: Runs `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` on every push and pull request.
2.  **Auto-Fix**: If the linting fails and the event is a push to the `rust` branch, it automatically runs `cargo fmt` and `cargo clippy --fix`.
3.  **Pull Request**: If fixes were made, it uses `peter-evans/create-pull-request` to submit a PR to the `rust` branch.
4.  **Workaround**: It creates a dummy `web/out/index.html` file so that the `hjweb` crate (which uses `rust-embed`) can be linted without needing a full frontend build artifact.
5.  **Permissions**: Added `contents: write` and `pull-requests: write` permissions to ensure the job can create PRs.

---
*PR created automatically by Jules for task [13391715434731235363](https://jules.google.com/task/13391715434731235363) started by @Asutorufa*