### PR TITLE
feat: migrate custom LLM providers configuration to d1-orm database

### DIFF
--- a/common/src/ai.rs
+++ b/common/src/ai.rs
@@ -354,7 +354,7 @@ pub async fn google_search_req_stream<'a>(
 
 #[derive(serde::Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
-enum ProviderType {
+pub enum ProviderType {
     #[default]
     OpenAI,
     Gemini,
@@ -363,14 +363,14 @@ enum ProviderType {
 }
 
 #[derive(serde::Deserialize)]
-struct ConfigProvider {
-    name: String,
-    base_url: Option<String>,
-    api_key: Option<String>,
-    provider: Option<ProviderType>,
-    models: Vec<String>,
-    project_id: Option<String>,
-    location: Option<String>,
+pub struct ConfigProvider {
+    pub name: String,
+    pub base_url: Option<String>,
+    pub api_key: Option<String>,
+    pub provider: Option<ProviderType>,
+    pub models: Vec<String>,
+    pub project_id: Option<String>,
+    pub location: Option<String>,
 }
 
 impl From<ConfigProvider> for hj_ai::provider::Provider {

--- a/common/src/d1.rs
+++ b/common/src/d1.rs
@@ -107,6 +107,7 @@ define_sql!(
     "#,
 
     DeleteLlmProvider { name: &'a str } => "DELETE FROM llm_providers WHERE name = ?",
+    GetLlmProviderByName { name: &'a str } => "SELECT * FROM llm_providers WHERE name = ?",
 );
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/common/src/d1.rs
+++ b/common/src/d1.rs
@@ -32,6 +32,20 @@ define_model!(
     }
 );
 
+define_model!(
+    LlmProvider,
+    LlmProviderField,
+    LlmProviderUpdate {
+        name: String[pk],
+        base_url: String,
+        api_key: String,
+        provider: String,
+        models: String,
+        project_id: String,
+        location: String,
+    }
+);
+
 define_sql!(
     Queries
 
@@ -69,6 +83,30 @@ define_sql!(
         example: &'a str,
         old_word: &'a str
     } => "UPDATE words SET word = ?1, explain = ?2, update_time = strftime('%s', 'now'), word_type = ?3, example = ?4 WHERE word = ?5",
+
+    ListLlmProviders => "SELECT * FROM llm_providers",
+
+    SaveLlmProvider {
+        name: &'a str,
+        base_url: &'a str,
+        api_key: &'a str,
+        provider: &'a str,
+        models: &'a str,
+        project_id: &'a str,
+        location: &'a str
+    } => r#"
+        INSERT INTO llm_providers (name, base_url, api_key, provider, models, project_id, location)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        ON CONFLICT(name) DO UPDATE SET
+            base_url = excluded.base_url,
+            api_key = excluded.api_key,
+            provider = excluded.provider,
+            models = excluded.models,
+            project_id = excluded.project_id,
+            location = excluded.location
+    "#,
+
+    DeleteLlmProvider { name: &'a str } => "DELETE FROM llm_providers WHERE name = ?",
 );
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -133,6 +171,24 @@ pub fn migrations() -> Vec<Migration<SqlStatement>> {
             vec![SqlStatement(
                 r#"
             ALTER TABLE words RENAME COLUMN type TO word_type;
+            "#
+                .to_string(),
+            )],
+        ),
+        Migration::new(
+            3,
+            "add_llm_providers",
+            vec![SqlStatement(
+                r#"
+            CREATE TABLE IF NOT EXISTS llm_providers (
+                "name" TEXT PRIMARY KEY,
+                "base_url" TEXT DEFAULT '',
+                "api_key" TEXT DEFAULT '',
+                "provider" TEXT DEFAULT '',
+                "models" TEXT DEFAULT '',
+                "project_id" TEXT DEFAULT '',
+                "location" TEXT DEFAULT ''
+            );
             "#
                 .to_string(),
             )],

--- a/common/src/opts.rs
+++ b/common/src/opts.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use frankenstein::client_reqwest;
@@ -13,7 +13,6 @@ pub struct RunOpt<T: DatabaseExecutor, T2: crate::ai::Translator> {
     pub translator: T2,
     pub workers_ai: Option<hj_ai::provider::Provider>,
     pub bot: client_reqwest::Bot,
-    pub custom_llms: HashMap<String, hj_ai::provider::Provider>,
     pub auth_secret: String,
     pub auth_username: String,
     pub auth_password: String,

--- a/common/src/route.rs
+++ b/common/src/route.rs
@@ -330,7 +330,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                 }
             }
             _ => {
-                if path.starts_with("/word/") {
+                if path.starts_with("/word/") || path.starts_with("/llm/") {
                     if let Err(e) = self.check_auth(auth_header) {
                         return Ok(UnifiedResponse::error(401, e));
                     }
@@ -356,6 +356,9 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
             "/word/remind_count_increment" => self.increment_remind_count(body).await,
             "/word/priority" => self.change_priority(body).await,
             "/word/ai_custom" => self.custom_llms().await,
+            "/llm/list" => self.list_llm_providers().await,
+            "/llm/save" => self.save_llm_provider(body).await,
+            "/llm/delete" => self.delete_llm_provider(body).await,
             _ => Err(Error::NotFound),
         }
     }
@@ -466,6 +469,58 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
         Ok([b'{', b'}'].to_vec())
     }
 
+    pub async fn list_llm_providers(&self) -> Result<Vec<u8>, Error> {
+        let providers: Vec<crate::d1::LlmProvider> = self.d1.query_all(crate::d1::Queries::ListLlmProviders).await?;
+        Ok(serde_json::to_vec(&providers)?)
+    }
+
+    pub async fn save_llm_provider(&self, body: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let req = serde_json::from_slice::<crate::d1::LlmProvider>(&body)?;
+        self.d1.execute(crate::d1::Queries::SaveLlmProvider {
+            name: &req.name,
+            base_url: &req.base_url,
+            api_key: &req.api_key,
+            provider: &req.provider,
+            models: &req.models,
+            project_id: &req.project_id,
+            location: &req.location,
+        }).await?;
+        Ok([b'{', b'}'].to_vec())
+    }
+
+    pub async fn delete_llm_provider(&self, body: Vec<u8>) -> Result<Vec<u8>, Error> {
+        #[derive(Deserialize)]
+        struct DeleteReq {
+            name: String,
+        }
+        let req = serde_json::from_slice::<DeleteReq>(&body)?;
+        self.d1.execute(crate::d1::Queries::DeleteLlmProvider { name: &req.name }).await?;
+        Ok([b'{', b'}'].to_vec())
+    }
+
+    pub async fn get_custom_llm_providers(&self) -> Result<std::collections::HashMap<String, hj_ai::provider::Provider>, Error> {
+        let providers: Vec<crate::d1::LlmProvider> = self.d1.query_all(crate::d1::Queries::ListLlmProviders).await?;
+        let mut custom_llms = std::collections::HashMap::new();
+        for p in providers {
+            let config = crate::ai::ConfigProvider {
+                name: p.name.clone(),
+                base_url: if p.base_url.is_empty() { None } else { Some(p.base_url) },
+                api_key: if p.api_key.is_empty() { None } else { Some(p.api_key) },
+                provider: match p.provider.as_str() {
+                    "gemini" => Some(crate::ai::ProviderType::Gemini),
+                    "vertexai" => Some(crate::ai::ProviderType::VertexAI),
+                    "workersai" => Some(crate::ai::ProviderType::WorkersAI),
+                    _ => Some(crate::ai::ProviderType::OpenAI),
+                },
+                models: p.models.split(',').filter(|s| !s.trim().is_empty()).map(|s| s.trim().to_string()).collect(),
+                project_id: if p.project_id.is_empty() { None } else { Some(p.project_id) },
+                location: if p.location.is_empty() { None } else { Some(p.location) },
+            };
+            custom_llms.insert(p.name, hj_ai::provider::Provider::from(config));
+        }
+        Ok(custom_llms)
+    }
+
     pub async fn custom_llms(&self) -> Result<Vec<u8>, Error> {
         let mut models = vec![];
 
@@ -476,7 +531,9 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
             });
         }
 
-        for (name, l) in self.custom_llms.iter() {
+        let custom_llms = self.get_custom_llm_providers().await?;
+
+        for (name, l) in custom_llms.iter() {
             models.push(CustomLLMResponse {
                 name: name.clone(),
                 models: l.models(),
@@ -510,22 +567,25 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                         )
                         .await?,
                     ),
-                    _ => Some(
-                        crate::ai::explain(
-                            self.custom_llms
-                                .get(name)
-                                .ok_or(Error::Internal("custom llm not found".to_string()))?,
-                            req.google_search.unwrap_or(false),
-                            crate::ai::TranslateRequest {
-                                model,
-                                chars_limit: false,
-                                query: &req.word,
-                                instruction: req.instruction().as_deref(),
-                                dst_lang: req.dst_lang.as_deref(),
-                            },
+                    _ => {
+                        let custom_llms = self.get_custom_llm_providers().await?;
+                        Some(
+                            crate::ai::explain(
+                                custom_llms
+                                    .get(name)
+                                    .ok_or(Error::Internal("custom llm not found".to_string()))?,
+                                req.google_search.unwrap_or(false),
+                                crate::ai::TranslateRequest {
+                                    model,
+                                    chars_limit: false,
+                                    query: &req.word,
+                                    instruction: req.instruction().as_deref(),
+                                    dst_lang: req.dst_lang.as_deref(),
+                                },
+                            )
+                            .await?,
                         )
-                        .await?,
-                    ),
+                    }
                 }
             }
             _ => None,
@@ -645,8 +705,9 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                         .await?
                     }
                     _ => {
+                        let custom_llms = self.get_custom_llm_providers().await?;
                         crate::ai::explain_stream(
-                            self.custom_llms
+                            custom_llms
                                 .get(name)
                                 .ok_or(Error::Internal("custom llm not found".to_string()))?,
                             req.google_search.unwrap_or(false),

--- a/common/src/route.rs
+++ b/common/src/route.rs
@@ -470,21 +470,26 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
     }
 
     pub async fn list_llm_providers(&self) -> Result<Vec<u8>, Error> {
-        let providers: Vec<crate::d1::LlmProvider> = self.d1.query_all(crate::d1::Queries::ListLlmProviders).await?;
+        let providers: Vec<crate::d1::LlmProvider> = self
+            .d1
+            .query_all(crate::d1::Queries::ListLlmProviders)
+            .await?;
         Ok(serde_json::to_vec(&providers)?)
     }
 
     pub async fn save_llm_provider(&self, body: Vec<u8>) -> Result<Vec<u8>, Error> {
         let req = serde_json::from_slice::<crate::d1::LlmProvider>(&body)?;
-        self.d1.execute(crate::d1::Queries::SaveLlmProvider {
-            name: &req.name,
-            base_url: &req.base_url,
-            api_key: &req.api_key,
-            provider: &req.provider,
-            models: &req.models,
-            project_id: &req.project_id,
-            location: &req.location,
-        }).await?;
+        self.d1
+            .execute(crate::d1::Queries::SaveLlmProvider {
+                name: &req.name,
+                base_url: &req.base_url,
+                api_key: &req.api_key,
+                provider: &req.provider,
+                models: &req.models,
+                project_id: &req.project_id,
+                location: &req.location,
+            })
+            .await?;
         Ok([b'{', b'}'].to_vec())
     }
 
@@ -494,27 +499,55 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
             name: String,
         }
         let req = serde_json::from_slice::<DeleteReq>(&body)?;
-        self.d1.execute(crate::d1::Queries::DeleteLlmProvider { name: &req.name }).await?;
+        self.d1
+            .execute(crate::d1::Queries::DeleteLlmProvider { name: &req.name })
+            .await?;
         Ok([b'{', b'}'].to_vec())
     }
 
-    pub async fn get_custom_llm_providers(&self) -> Result<std::collections::HashMap<String, hj_ai::provider::Provider>, Error> {
-        let providers: Vec<crate::d1::LlmProvider> = self.d1.query_all(crate::d1::Queries::ListLlmProviders).await?;
+    pub async fn get_custom_llm_providers(
+        &self,
+    ) -> Result<std::collections::HashMap<String, hj_ai::provider::Provider>, Error> {
+        let providers: Vec<crate::d1::LlmProvider> = self
+            .d1
+            .query_all(crate::d1::Queries::ListLlmProviders)
+            .await?;
         let mut custom_llms = std::collections::HashMap::new();
         for p in providers {
             let config = crate::ai::ConfigProvider {
                 name: p.name.clone(),
-                base_url: if p.base_url.is_empty() { None } else { Some(p.base_url) },
-                api_key: if p.api_key.is_empty() { None } else { Some(p.api_key) },
+                base_url: if p.base_url.is_empty() {
+                    None
+                } else {
+                    Some(p.base_url)
+                },
+                api_key: if p.api_key.is_empty() {
+                    None
+                } else {
+                    Some(p.api_key)
+                },
                 provider: match p.provider.as_str() {
                     "gemini" => Some(crate::ai::ProviderType::Gemini),
                     "vertexai" => Some(crate::ai::ProviderType::VertexAI),
                     "workersai" => Some(crate::ai::ProviderType::WorkersAI),
                     _ => Some(crate::ai::ProviderType::OpenAI),
                 },
-                models: p.models.split(',').filter(|s| !s.trim().is_empty()).map(|s| s.trim().to_string()).collect(),
-                project_id: if p.project_id.is_empty() { None } else { Some(p.project_id) },
-                location: if p.location.is_empty() { None } else { Some(p.location) },
+                models: p
+                    .models
+                    .split(',')
+                    .filter(|s| !s.trim().is_empty())
+                    .map(|s| s.trim().to_string())
+                    .collect(),
+                project_id: if p.project_id.is_empty() {
+                    None
+                } else {
+                    Some(p.project_id)
+                },
+                location: if p.location.is_empty() {
+                    None
+                } else {
+                    Some(p.location)
+                },
             };
             custom_llms.insert(p.name, hj_ai::provider::Provider::from(config));
         }

--- a/common/src/route.rs
+++ b/common/src/route.rs
@@ -514,44 +514,60 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
             .await?;
         let mut custom_llms = std::collections::HashMap::new();
         for p in providers {
-            let config = crate::ai::ConfigProvider {
-                name: p.name.clone(),
-                base_url: if p.base_url.is_empty() {
-                    None
-                } else {
-                    Some(p.base_url)
-                },
-                api_key: if p.api_key.is_empty() {
-                    None
-                } else {
-                    Some(p.api_key)
-                },
-                provider: match p.provider.as_str() {
-                    "gemini" => Some(crate::ai::ProviderType::Gemini),
-                    "vertexai" => Some(crate::ai::ProviderType::VertexAI),
-                    "workersai" => Some(crate::ai::ProviderType::WorkersAI),
-                    _ => Some(crate::ai::ProviderType::OpenAI),
-                },
-                models: p
-                    .models
-                    .split(',')
-                    .filter(|s| !s.trim().is_empty())
-                    .map(|s| s.trim().to_string())
-                    .collect(),
-                project_id: if p.project_id.is_empty() {
-                    None
-                } else {
-                    Some(p.project_id)
-                },
-                location: if p.location.is_empty() {
-                    None
-                } else {
-                    Some(p.location)
-                },
-            };
-            custom_llms.insert(p.name, hj_ai::provider::Provider::from(config));
+            custom_llms.insert(p.name.clone(), Self::map_llm_provider_to_config(p));
         }
         Ok(custom_llms)
+    }
+
+    pub async fn get_llm_provider_by_name(
+        &self,
+        name: &str,
+    ) -> Result<hj_ai::provider::Provider, Error> {
+        let p: Option<crate::d1::LlmProvider> = self
+            .d1
+            .query_first(crate::d1::Queries::GetLlmProviderByName { name })
+            .await?;
+        let p = p.ok_or_else(|| Error::Internal("custom llm not found".to_string()))?;
+        Ok(Self::map_llm_provider_to_config(p))
+    }
+
+    fn map_llm_provider_to_config(p: crate::d1::LlmProvider) -> hj_ai::provider::Provider {
+        let config = crate::ai::ConfigProvider {
+            name: p.name.clone(),
+            base_url: if p.base_url.is_empty() {
+                None
+            } else {
+                Some(p.base_url)
+            },
+            api_key: if p.api_key.is_empty() {
+                None
+            } else {
+                Some(p.api_key)
+            },
+            provider: match p.provider.as_str() {
+                "gemini" => Some(crate::ai::ProviderType::Gemini),
+                "vertexai" => Some(crate::ai::ProviderType::VertexAI),
+                "workersai" => Some(crate::ai::ProviderType::WorkersAI),
+                _ => Some(crate::ai::ProviderType::OpenAI),
+            },
+            models: p
+                .models
+                .split(',')
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| s.trim().to_string())
+                .collect(),
+            project_id: if p.project_id.is_empty() {
+                None
+            } else {
+                Some(p.project_id)
+            },
+            location: if p.location.is_empty() {
+                None
+            } else {
+                Some(p.location)
+            },
+        };
+        hj_ai::provider::Provider::from(config)
     }
 
     pub async fn custom_llms(&self) -> Result<Vec<u8>, Error> {
@@ -601,12 +617,10 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                         .await?,
                     ),
                     _ => {
-                        let custom_llms = self.get_custom_llm_providers().await?;
+                        let provider = self.get_llm_provider_by_name(name).await?;
                         Some(
                             crate::ai::explain(
-                                custom_llms
-                                    .get(name)
-                                    .ok_or(Error::Internal("custom llm not found".to_string()))?,
+                                &provider,
                                 req.google_search.unwrap_or(false),
                                 crate::ai::TranslateRequest {
                                     model,
@@ -738,11 +752,9 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                         .await?
                     }
                     _ => {
-                        let custom_llms = self.get_custom_llm_providers().await?;
+                        let provider = self.get_llm_provider_by_name(name).await?;
                         crate::ai::explain_stream(
-                            custom_llms
-                                .get(name)
-                                .ok_or(Error::Internal("custom llm not found".to_string()))?,
+                            &provider,
                             req.google_search.unwrap_or(false),
                             crate::ai::TranslateRequest {
                                 model,

--- a/native/src/opts.rs
+++ b/native/src/opts.rs
@@ -2,7 +2,7 @@ use crate::ai::Workers;
 use crate::d1::{D1, Database};
 use frankenstein::client_reqwest;
 use hjcommon::opts::RunOpt;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 pub async fn run_opts() -> Result<RunOpt<D1, Workers>, Box<dyn std::error::Error>> {
@@ -71,7 +71,6 @@ pub async fn run_opts() -> Result<RunOpt<D1, Workers>, Box<dyn std::error::Error
             }))
         },
         bot: client_reqwest::Bot::new(&telegram_bot_token),
-        custom_llms: HashMap::new(),
         auth_secret,
         auth_username,
         auth_password,

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -11,6 +11,11 @@ use lambda_runtime::LambdaEvent;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use hjcommon::d1::migrations;
+
+static MIGRATION_DONE: AtomicBool = AtomicBool::new(false);
+
 #[tokio::main]
 async fn main() -> Result<(), lambda_runtime::Error> {
     env_logger::builder()
@@ -18,6 +23,14 @@ async fn main() -> Result<(), lambda_runtime::Error> {
         .init();
 
     let run_opt = run_opts().await.unwrap();
+
+    if MIGRATION_DONE
+        .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+        .is_ok()
+        && let Err(e) = d1_orm::migrate(&run_opt.d1, migrations(), None, Some(|s: &str| log::info!("{}", s))).await
+    {
+        log::error!("Migration failed: {}", e);
+    }
 
     let handler = LambdaHandler {
         run_opt: Arc::new(run_opt),

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -11,8 +11,8 @@ use lambda_runtime::LambdaEvent;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use hjcommon::d1::migrations;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 static MIGRATION_DONE: AtomicBool = AtomicBool::new(false);
 
@@ -27,7 +27,13 @@ async fn main() -> Result<(), lambda_runtime::Error> {
     if MIGRATION_DONE
         .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
         .is_ok()
-        && let Err(e) = d1_orm::migrate(&run_opt.d1, migrations(), None, Some(|s: &str| log::info!("{}", s))).await
+        && let Err(e) = d1_orm::migrate(
+            &run_opt.d1,
+            migrations(),
+            None,
+            Some(|s: &str| log::info!("{}", s)),
+        )
+        .await
     {
         log::error!("Migration failed: {}", e);
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,10 +7,12 @@ import { useScrollDirection } from "@/hooks/useScrollDirection";
 import Home from "./pages/Home";
 import Words from "./pages/Words";
 import Flashcard from "./pages/Flashcard";
+import Llm from "./pages/Llm";
 import Login from "./pages/Login";
 import {
   ROUTE_FLASHCARD,
   ROUTE_HOME,
+  ROUTE_LLM,
   ROUTE_LOGIN,
   ROUTE_WORDS,
 } from "./lib/constants";
@@ -54,6 +56,7 @@ function Main() {
                 href={ROUTE_FLASHCARD}
                 key={ROUTE_FLASHCARD}
               />
+              <Tab title="LLM" href={ROUTE_LLM} key={ROUTE_LLM} />
             </Tabs>
           </div>
         )}
@@ -63,6 +66,7 @@ function Main() {
           <Route path={ROUTE_LOGIN} component={Login} />
           <Route path={ROUTE_WORDS} component={Words} />
           <Route path={ROUTE_FLASHCARD} component={Flashcard} />
+          <Route path={ROUTE_LLM} component={Llm} />
         </Switch>
       </NextThemesProvider>
     </HeroUIProvider>

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -4,3 +4,4 @@ export const ROUTE_LOGIN = "/login";
 export const ROUTE_HOME = "/";
 export const ROUTE_WORDS = "/docs/words";
 export const ROUTE_FLASHCARD = "/docs/flashcard";
+export const ROUTE_LLM = "/docs/llm";

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -168,6 +168,28 @@ export const handlers = [
     ]);
   }),
 
+  http.post("/llm/list", () => {
+    return HttpResponse.json([
+      {
+        name: "Mock LLM",
+        base_url: "https://api.openai.com",
+        api_key: "sk-...",
+        provider: "openai",
+        models: "gpt-4-mock,claude-mock",
+        project_id: "",
+        location: "",
+      },
+    ]);
+  }),
+
+  http.post("/llm/save", () => {
+    return HttpResponse.json({});
+  }),
+
+  http.post("/llm/delete", () => {
+    return HttpResponse.json({});
+  }),
+
   http.post("/word/query", async ({ request }) => {
     type WordPayload = { word: string };
     const { word } = (await request.json()) as WordPayload;

--- a/web/src/pages/Llm.tsx
+++ b/web/src/pages/Llm.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Card,
+  CardBody,
+  Input,
+  Select,
+  SelectItem,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+} from "@heroui/react";
+import { authorizedRequest } from "../lib/api";
+import { useLocation } from "wouter";
+import { ROUTE_LOGIN } from "../lib/constants";
+
+export type LlmProvider = {
+  name: string;
+  base_url: string;
+  api_key: string;
+  provider: string;
+  models: string;
+  project_id: string;
+  location: string;
+};
+
+export default function Llm() {
+  const [, setLocation] = useLocation();
+  const [providers, setProviders] = useState<LlmProvider[]>([]);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [editingProvider, setEditingProvider] = useState<LlmProvider | null>(null);
+
+  const fetchProviders = async () => {
+    try {
+      const res = await authorizedRequest("/llm/list", {
+        method: "POST",
+      });
+      if (!res.ok) {
+        if (res.status === 401) {
+          setLocation(ROUTE_LOGIN);
+        }
+        return;
+      }
+      const data = await res.json();
+      setProviders(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    fetchProviders();
+  }, []);
+
+  const handleDelete = async (name: string) => {
+    try {
+      await authorizedRequest("/llm/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      fetchProviders();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const data = Object.fromEntries(formData.entries());
+
+    try {
+      await authorizedRequest("/llm/save", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      onClose();
+      fetchProviders();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const openAddModal = () => {
+    setEditingProvider(null);
+    onOpen();
+  };
+
+  const openEditModal = (provider: LlmProvider) => {
+    setEditingProvider(provider);
+    onOpen();
+  };
+
+  return (
+    <div className="container mx-auto p-4 max-w-4xl pb-32">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">LLM Providers</h1>
+        <Button color="primary" onPress={openAddModal}>
+          Add Provider
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {providers.map((p) => (
+          <Card key={p.name}>
+            <CardBody>
+              <div className="flex justify-between items-start">
+                <div>
+                  <h3 className="text-lg font-semibold">{p.name}</h3>
+                  <p className="text-sm text-gray-500">{p.provider}</p>
+                  {p.base_url && <p className="text-xs truncate">{p.base_url}</p>}
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" onPress={() => openEditModal(p)}>
+                    Edit
+                  </Button>
+                  <Button size="sm" color="danger" onPress={() => handleDelete(p.name)}>
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            </CardBody>
+          </Card>
+        ))}
+      </div>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalContent>
+          <form onSubmit={handleSave}>
+            <ModalHeader>
+              {editingProvider ? "Edit Provider" : "Add Provider"}
+            </ModalHeader>
+            <ModalBody>
+              <Input
+                name="name"
+                label="Name"
+                defaultValue={editingProvider?.name}
+                isReadOnly={!!editingProvider}
+                required
+              />
+              <Select
+                name="provider"
+                label="Provider Type"
+                defaultSelectedKeys={editingProvider ? [editingProvider.provider] : ["openai"]}
+              >
+                <SelectItem key="openai" value="openai">OpenAI</SelectItem>
+                <SelectItem key="gemini" value="gemini">Gemini</SelectItem>
+                <SelectItem key="vertexai" value="vertexai">VertexAI</SelectItem>
+                <SelectItem key="workersai" value="workersai">Workers AI</SelectItem>
+              </Select>
+              <Input
+                name="base_url"
+                label="Base URL (Optional)"
+                defaultValue={editingProvider?.base_url}
+              />
+              <Input
+                name="api_key"
+                label="API Key"
+                type="password"
+                defaultValue={editingProvider?.api_key}
+              />
+              <Input
+                name="models"
+                label="Models (comma separated)"
+                defaultValue={editingProvider?.models}
+                required
+              />
+              <Input
+                name="project_id"
+                label="Project ID (for VertexAI)"
+                defaultValue={editingProvider?.project_id}
+              />
+              <Input
+                name="location"
+                label="Location (for VertexAI)"
+                defaultValue={editingProvider?.location}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button color="danger" variant="light" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button color="primary" type="submit">
+                Save
+              </Button>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}

--- a/web/src/pages/Llm.tsx
+++ b/web/src/pages/Llm.tsx
@@ -59,6 +59,9 @@ export default function Llm() {
   }, []);
 
   const handleDelete = async (name: string) => {
+    if (!window.confirm(`Are you sure you want to delete provider "${name}"?`)) {
+      return;
+    }
     try {
       await authorizedRequest("/llm/delete", {
         method: "POST",
@@ -88,6 +91,7 @@ export default function Llm() {
       fetchProviders();
     } catch (err) {
       console.error(err);
+      alert(`Failed to save provider: ${err instanceof Error ? err.message : String(err)}`);
     }
   };
 

--- a/web/src/pages/Llm.tsx
+++ b/web/src/pages/Llm.tsx
@@ -44,7 +44,7 @@ export default function Llm() {
         }
         return;
       }
-      const data = await res.json();
+      const data = (await res.json()) as LlmProvider[];
       setProviders(data);
     } catch (e) {
       console.error(e);
@@ -53,6 +53,7 @@ export default function Llm() {
 
   useEffect(() => {
     fetchProviders();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleDelete = async (name: string) => {
@@ -71,7 +72,7 @@ export default function Llm() {
   const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    const data = Object.fromEntries(formData.entries());
+    const data = Object.fromEntries(formData.entries()) as unknown as LlmProvider;
 
     try {
       await authorizedRequest("/llm/save", {
@@ -148,10 +149,10 @@ export default function Llm() {
                 label="Provider Type"
                 defaultSelectedKeys={editingProvider ? [editingProvider.provider] : ["openai"]}
               >
-                <SelectItem key="openai" value="openai">OpenAI</SelectItem>
-                <SelectItem key="gemini" value="gemini">Gemini</SelectItem>
-                <SelectItem key="vertexai" value="vertexai">VertexAI</SelectItem>
-                <SelectItem key="workersai" value="workersai">Workers AI</SelectItem>
+                <SelectItem key="openai">OpenAI</SelectItem>
+                <SelectItem key="gemini">Gemini</SelectItem>
+                <SelectItem key="vertexai">VertexAI</SelectItem>
+                <SelectItem key="workersai">Workers AI</SelectItem>
               </Select>
               <Input
                 name="base_url"

--- a/web/src/pages/Llm.tsx
+++ b/web/src/pages/Llm.tsx
@@ -59,7 +59,9 @@ export default function Llm() {
   }, []);
 
   const handleDelete = async (name: string) => {
-    if (!window.confirm(`Are you sure you want to delete provider "${name}"?`)) {
+    if (
+      !window.confirm(`Are you sure you want to delete provider "${name}"?`)
+    ) {
       return;
     }
     try {
@@ -91,7 +93,9 @@ export default function Llm() {
       fetchProviders();
     } catch (err) {
       console.error(err);
-      alert(`Failed to save provider: ${err instanceof Error ? err.message : String(err)}`);
+      alert(
+        `Failed to save provider: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   };
 

--- a/web/src/pages/Llm.tsx
+++ b/web/src/pages/Llm.tsx
@@ -31,7 +31,9 @@ export default function Llm() {
   const [, setLocation] = useLocation();
   const [providers, setProviders] = useState<LlmProvider[]>([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [editingProvider, setEditingProvider] = useState<LlmProvider | null>(null);
+  const [editingProvider, setEditingProvider] = useState<LlmProvider | null>(
+    null,
+  );
 
   const fetchProviders = async () => {
     try {
@@ -72,7 +74,9 @@ export default function Llm() {
   const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    const data = Object.fromEntries(formData.entries()) as unknown as LlmProvider;
+    const data = Object.fromEntries(
+      formData.entries(),
+    ) as unknown as LlmProvider;
 
     try {
       await authorizedRequest("/llm/save", {
@@ -114,13 +118,19 @@ export default function Llm() {
                 <div>
                   <h3 className="text-lg font-semibold">{p.name}</h3>
                   <p className="text-sm text-gray-500">{p.provider}</p>
-                  {p.base_url && <p className="text-xs truncate">{p.base_url}</p>}
+                  {p.base_url && (
+                    <p className="text-xs truncate">{p.base_url}</p>
+                  )}
                 </div>
                 <div className="flex gap-2">
                   <Button size="sm" onPress={() => openEditModal(p)}>
                     Edit
                   </Button>
-                  <Button size="sm" color="danger" onPress={() => handleDelete(p.name)}>
+                  <Button
+                    size="sm"
+                    color="danger"
+                    onPress={() => handleDelete(p.name)}
+                  >
                     Delete
                   </Button>
                 </div>
@@ -147,7 +157,9 @@ export default function Llm() {
               <Select
                 name="provider"
                 label="Provider Type"
-                defaultSelectedKeys={editingProvider ? [editingProvider.provider] : ["openai"]}
+                defaultSelectedKeys={
+                  editingProvider ? [editingProvider.provider] : ["openai"]
+                }
               >
                 <SelectItem key="openai">OpenAI</SelectItem>
                 <SelectItem key="gemini">Gemini</SelectItem>

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -3,17 +3,18 @@ pub mod consolelog;
 
 use crate::ai::WasmAI;
 use frankenstein::client_reqwest;
-use hjcommon::ai::providers_from_assets;
 use hjcommon::opts::RunOpt;
 use hjcommon::tg::send_random_word;
 use log::error;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Once, OnceLock};
-use std::{collections::HashMap, collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 use worker::*;
+use hjcommon::d1::migrations;
 
 static INIT: Once = Once::new();
 static ENV_CONFIG: OnceLock<EnvConfig> = OnceLock::new();
-static CUSTOM_LLMS: OnceLock<HashMap<String, hj_ai::provider::Provider>> = OnceLock::new();
+static MIGRATION_DONE: AtomicBool = AtomicBool::new(false);
 
 struct EnvConfig {
     allow_users: Arc<HashSet<i64>>,
@@ -95,7 +96,6 @@ async fn get_opt(env: Env) -> Arc<RunOpt<worker::D1Database, WasmAI>> {
         },
         matainer: config.maintainer_id,
         bot: config.bot.clone(),
-        custom_llms: CUSTOM_LLMS.get_or_init(providers_from_assets).clone(),
         auth_secret: config.auth_secret.clone(),
         auth_username: config.auth_username.clone(),
         auth_password: config.auth_password.clone(),
@@ -112,6 +112,14 @@ async fn main(mut req: Request, env: Env, ctx: Context) -> Result<Response> {
     ctx.pass_through_on_exception();
 
     let opt = get_opt(env.clone()).await;
+
+    if MIGRATION_DONE
+        .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+        .is_ok()
+        && let Err(e) = d1_orm::migrate(&opt.d1, migrations(), None, Some(|s: &str| console_log!("{}", s))).await
+    {
+        error!("Migration failed: {}", e);
+    }
 
     let req_clone = req.clone()?;
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -3,6 +3,7 @@ pub mod consolelog;
 
 use crate::ai::WasmAI;
 use frankenstein::client_reqwest;
+use hjcommon::d1::migrations;
 use hjcommon::opts::RunOpt;
 use hjcommon::tg::send_random_word;
 use log::error;
@@ -10,7 +11,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Once, OnceLock};
 use std::{collections::HashSet, sync::Arc};
 use worker::*;
-use hjcommon::d1::migrations;
 
 static INIT: Once = Once::new();
 static ENV_CONFIG: OnceLock<EnvConfig> = OnceLock::new();
@@ -116,7 +116,13 @@ async fn main(mut req: Request, env: Env, ctx: Context) -> Result<Response> {
     if MIGRATION_DONE
         .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
         .is_ok()
-        && let Err(e) = d1_orm::migrate(&opt.d1, migrations(), None, Some(|s: &str| console_log!("{}", s))).await
+        && let Err(e) = d1_orm::migrate(
+            &opt.d1,
+            migrations(),
+            None,
+            Some(|s: &str| console_log!("{}", s)),
+        )
+        .await
     {
         error!("Migration failed: {}", e);
     }


### PR DESCRIPTION
This PR fully automates the creation and management of custom LLM providers by migrating them from JSON asset files directly to the `d1_orm` database. It adds a new `llm_providers` database model, introduces an automatic migration process executed on initialization, updates backend routes and execution to query these providers, and adds a dedicated React frontend page to add/delete/manage custom LLM configs.

---
*PR created automatically by Jules for task [6710936587259612660](https://jules.google.com/task/6710936587259612660) started by @Asutorufa*