### PR TITLE
🔒 [security] Require AUTH_SECRET and remove weak default

### DIFF
--- a/native/src/opts.rs
+++ b/native/src/opts.rs
@@ -22,10 +22,10 @@ pub async fn run_opts() -> Result<RunOpt<D1, Workers>, Box<dyn std::error::Error
     let cloudflare_d1_database_name =
         std::env::var("CLOUDFLARE_D1_DATABASE_NAME").unwrap_or("".to_string());
 
-    let auth_secret = std::env::var("AUTH_SECRET")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "default_secret".to_string());
+    let auth_secret = std::env::var("AUTH_SECRET")?;
+    if auth_secret.is_empty() {
+        return Err("AUTH_SECRET is empty".into());
+    }
 
     let auth_username = std::env::var("AUTH_USERNAME").unwrap_or("".to_string());
     let auth_password = std::env::var("AUTH_PASSWORD").unwrap_or("".to_string());

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -27,7 +27,7 @@ struct EnvConfig {
 }
 
 impl EnvConfig {
-    fn from_env(env: &Env) -> Self {
+    fn from_env(env: &Env) -> Result<Self> {
         let token = get_string_from_env(env, "TELEGRAM_TOKEN");
         let bot = client_reqwest::Bot::new(&token);
 
@@ -42,12 +42,12 @@ impl EnvConfig {
                 .map(|v| v.parse::<i64>().unwrap_or(0)),
         );
 
-        let auth_secret = match get_string_from_env(env, "AUTH_SECRET") {
-            s if s.is_empty() => "default_secret".to_string(),
-            s => s,
-        };
+        let auth_secret = get_string_from_env(env, "AUTH_SECRET");
+        if auth_secret.is_empty() {
+            return Err(worker::Error::from("AUTH_SECRET is required"));
+        }
 
-        Self {
+        Ok(Self {
             allow_users: Arc::new(set),
             maintainer_id,
             bot,
@@ -57,7 +57,7 @@ impl EnvConfig {
             auth_token_expiration: get_string_from_env(env, "AUTH_TOKEN_EXPIRATION")
                 .parse::<i64>()
                 .unwrap_or(1),
-        }
+        })
     }
 }
 
@@ -68,7 +68,7 @@ fn get_string_from_env(env: &Env, key: &str) -> String {
     }
 }
 
-async fn get_opt(env: Env) -> Arc<RunOpt<worker::D1Database, WasmAI>> {
+async fn get_opt(env: Env) -> Result<Arc<RunOpt<worker::D1Database, WasmAI>>> {
     console_error_panic_hook::set_once();
     INIT.call_once(|| {
         match consolelog::init_with_level(log::Level::Info) {
@@ -77,13 +77,20 @@ async fn get_opt(env: Env) -> Arc<RunOpt<worker::D1Database, WasmAI>> {
         };
     });
 
-    let config = ENV_CONFIG.get_or_init(|| EnvConfig::from_env(&env));
+    let config = match ENV_CONFIG.get() {
+        Some(c) => c,
+        None => {
+            let c = EnvConfig::from_env(&env)?;
+            let _ = ENV_CONFIG.set(c);
+            ENV_CONFIG.get().unwrap()
+        }
+    };
 
     if let Ok(ai) = env.ai("AI") {
         hj_ai::workers::set_global_ai(ai);
     }
 
-    Arc::new(RunOpt {
+    Ok(Arc::new(RunOpt {
         allow_users: config.allow_users.clone(),
         d1: env.d1("DB").expect("D1 binding not found"),
         translator: WasmAI::new(&env, "AI"),
@@ -116,7 +123,7 @@ async fn main(mut req: Request, env: Env, ctx: Context) -> Result<Response> {
 
     ctx.pass_through_on_exception();
 
-    let opt = get_opt(env.clone()).await;
+    let opt = get_opt(env.clone()).await?;
 
     if MIGRATION_DONE
         .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
@@ -181,7 +188,13 @@ async fn main(mut req: Request, env: Env, ctx: Context) -> Result<Response> {
 
 #[event(scheduled)]
 async fn cron(_: ScheduledEvent, env: Env, _ctx: ScheduleContext) {
-    let opt = get_opt(env).await;
+    let opt = match get_opt(env).await {
+        Ok(opt) => opt,
+        Err(e) => {
+            error!("Failed to get opt: {}", e);
+            return;
+        }
+    };
 
     if let Err(e) = send_random_word(opt).await {
         error!("Error: {}", e);

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -77,14 +77,14 @@ async fn get_opt(env: Env) -> Result<Arc<RunOpt<worker::D1Database, WasmAI>>> {
         };
     });
 
-    let config = match ENV_CONFIG.get() {
-        Some(c) => c,
-        None => {
-            let c = EnvConfig::from_env(&env)?;
-            let _ = ENV_CONFIG.set(c);
-            ENV_CONFIG.get().unwrap()
-        }
-    };
+    if ENV_CONFIG.get().is_none() {
+        let c = EnvConfig::from_env(&env)?;
+        // In a race, the first thread to call `set` wins. We can ignore the error.
+        let _ = ENV_CONFIG.set(c);
+    }
+    let config = ENV_CONFIG
+        .get()
+        .expect("ENV_CONFIG is guaranteed to be initialized here");
 
     if let Ok(ai) = env.ai("AI") {
         hj_ai::workers::set_global_ai(ai);
@@ -112,7 +112,7 @@ async fn get_opt(env: Env) -> Result<Arc<RunOpt<worker::D1Database, WasmAI>>> {
         auth_username: config.auth_username.clone(),
         auth_password: config.auth_password.clone(),
         auth_token_expiration: config.auth_token_expiration,
-    })
+    }))
 }
 
 #[event(fetch)]


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR addresses a security vulnerability where the application would fall back to a hardcoded, publicly known default string (`"default_secret"`) if the `AUTH_SECRET` environment variable was not provided or was empty.

### ⚠️ Risk: The potential impact if left unfixed
Using a hardcoded default secret makes the authentication tokens (JWTs) predictable. An attacker could forge valid authentication tokens for any user (including the maintainer), leading to unauthorized access to all protected API endpoints, including word management and LLM queries.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix removes the default fallback in both the `native` (CLI) and `worker` (Cloudflare Worker) components. 
- In `native/src/opts.rs`, the `run_opts` function now returns an error if `AUTH_SECRET` is missing or empty.
- In `worker/src/lib.rs`, the `EnvConfig::from_env` function was updated to return a `Result`, and the initialization logic in `get_opt`, `main`, and `cron` was adjusted to handle and propagate this error.

This ensures that the application will fail to start if it is not securely configured with a custom secret.

---
*PR created automatically by Jules for task [3616321972304988976](https://jules.google.com/task/3616321972304988976) started by @Asutorufa*