### PR TITLE
🧹 [code health] Avoid unwrap() on async result in hj.rs

### DIFF
--- a/src/bin/hj.rs
+++ b/src/bin/hj.rs
@@ -2,7 +2,7 @@ use hjdict::{en, google, jp, kotobanku, kr, weblio};
 use std::env::args;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Debug)
         .init();
@@ -21,60 +21,52 @@ async fn main() {
   googlev1 <target> <words> - Old Google Translate API, eg: googlev1 en こんにちは
   help - show this message"#
         );
-        return;
+        return Ok(());
     }
 
     let word = &args[1..].join(" ");
     let result = match args[0].as_str() {
         "jc" => jp::get(word.as_str(), "jc")
-            .await
-            .unwrap()
+            .await?
             .iter()
             .map(|x| x.markdown())
             .collect::<Vec<_>>()
             .join("\n"),
         "cj" => jp::get(word.as_str(), "cj")
-            .await
-            .unwrap()
+            .await?
             .iter()
             .map(|x| x.markdown())
             .collect::<Vec<_>>()
             .join("\n"),
         "kr" => kr::get(word.as_str())
-            .await
-            .unwrap()
+            .await?
             .iter()
             .map(|x| x.markdown())
             .collect::<Vec<_>>()
             .join("\n"),
         "en" => en::get(word.as_str())
-            .await
-            .unwrap()
+            .await?
             .iter()
             .map(|x| x.markdown())
             .collect::<Vec<_>>()
             .join("\n"),
-        "weblio" => weblio::get(word).await.unwrap().join("\n"),
-        "ktbk" => kotobanku::get(word).await.unwrap().join("\n"),
+        "weblio" => weblio::get(word).await?.join("\n"),
+        "ktbk" => kotobanku::get(word).await?.join("\n"),
         "google" | "googlev1" => {
             let target = &args[1];
             let words = args[2..].join(" ");
 
             if words.is_empty() {
-                return;
+                return Err("No words provided for translation".into());
             }
 
-            let query = async |text: &str, src: Option<String>, target: &str| {
-                if args[0] == "googlev1" {
-                    return google::translate(text, src, target).await;
-                } else {
-                    return google::translatev2(text, src, target).await;
-                }
+            let outputs = if args[0] == "googlev1" {
+                google::translate(words.as_str(), None, target).await?
+            } else {
+                google::translatev2(words.as_str(), None, target).await?
             };
 
-            query(words.as_str(), None, target)
-                .await
-                .unwrap()
+            outputs
                 .iter()
                 .map(|x| x.translation.as_ref())
                 .collect::<Vec<_>>()
@@ -86,4 +78,5 @@ async fn main() {
     };
 
     println!("{}", result);
+    Ok(())
 }


### PR DESCRIPTION
Addressed PR feedback by returning an error message when no words are provided for translation in the google/googlev1 commands, instead of silently exiting. Re-submitting to the same branch to update the PR.

---
*PR created automatically by Jules for task [13760641830658289447](https://jules.google.com/task/13760641830658289447) started by @Asutorufa*