### PR TITLE
feat(web): add Google Translate TTS pronunciation buttons

### DIFF
--- a/web/src/components.tsx
+++ b/web/src/components.tsx
@@ -718,12 +718,11 @@ export function SpeakerIcon({ size = 24, width, height, ...props }: IconProps) {
   );
 }
 
-
-export const TTSButton: FC<{ text: string; lang: string; className?: string }> = ({
-  text,
-  lang,
-  className,
-}) => {
+export const TTSButton: FC<{
+  text: string;
+  lang: string;
+  className?: string;
+}> = ({ text, lang, className }) => {
   const [playing, setPlaying] = useState(false);
 
   const play = () => {

--- a/web/src/components.tsx
+++ b/web/src/components.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
   Text,
   Box,
+  IconButton,
 } from "@radix-ui/themes";
 import { FC, ReactNode, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -695,5 +696,70 @@ export function getPriorityText(priority: number) {
     return "High";
   }
 }
+
+export function SpeakerIcon({ size = 24, width, height, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size || width}
+      height={size || height}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+      <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+      <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
+    </svg>
+  );
+}
+
+
+export const TTSButton: FC<{ text: string; lang: string; className?: string }> = ({
+  text,
+  lang,
+  className,
+}) => {
+  const [playing, setPlaying] = useState(false);
+
+  const play = () => {
+    if (!text || playing) return;
+
+    // Google TTS URL construction
+    // max length is around 200 chars for google tts without tokens
+    const safeText = text.slice(0, 200);
+    const url = `https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&q=${encodeURIComponent(safeText)}&tl=${lang}`;
+
+    const audio = new Audio(url);
+
+    audio.onplay = () => setPlaying(true);
+    audio.onended = () => setPlaying(false);
+    audio.onerror = () => setPlaying(false);
+
+    audio.play().catch((e) => {
+      console.error("Failed to play TTS audio", e);
+      setPlaying(false);
+    });
+  };
+
+  return (
+    <IconButton
+      size="1"
+      variant="ghost"
+      color="gray"
+      className={`cursor-pointer ${className || ""}`}
+      onClick={play}
+      disabled={playing || !text}
+      title="Play Pronunciation"
+    >
+      <SpeakerIcon size={16} />
+    </IconButton>
+  );
+};
+
 export * from "./AudioPlayer";
 export * from "./Markdown";

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,7 +10,9 @@ async function enableMocking() {
   }
 
   const { worker } = await import("./mocks/browser");
-  return worker.start();
+  return worker.start({
+    onUnhandledRequest: "bypass",
+  });
 }
 
 enableMocking().then(() => {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -455,17 +455,17 @@ export default function Home() {
           <Card>
             <Box>
               <Flex justify="between" align="center" className="mb-2">
-              <Text
-                as="label"
-                size="1"
-                weight="bold"
-                color="gray"
-                className="block uppercase tracking-widest"
-              >
-                Input
-              </Text>
-              <TTSButton text={query} lang={srcLang || 'en'} />
-            </Flex>
+                <Text
+                  as="label"
+                  size="1"
+                  weight="bold"
+                  color="gray"
+                  className="block uppercase tracking-widest"
+                >
+                  Input
+                </Text>
+                <TTSButton text={query} lang={srcLang || "en"} />
+              </Flex>
               <TextArea
                 color={query.length === 0 ? "red" : undefined}
                 value={query}
@@ -595,7 +595,7 @@ export default function Home() {
               >
                 Result
               </Text>
-              <TTSButton text={result.result} lang={dstLang || 'en'} />
+              <TTSButton text={result.result} lang={dstLang || "en"} />
             </Flex>
             <Card>
               {result.result ? (

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import {
   Markdown,
   PlayIcon,
   SaveWordModal,
+  TTSButton,
 } from "../components";
 import { PageHeader } from "@/ui/PageHeader";
 import { PageContainer } from "@/ui/PageContainer";
@@ -453,15 +454,18 @@ export default function Home() {
         <motion.div variants={itemVariants} initial="hidden" animate="visible">
           <Card>
             <Box>
+              <Flex justify="between" align="center" className="mb-2">
               <Text
                 as="label"
                 size="1"
                 weight="bold"
                 color="gray"
-                className="mb-2 block uppercase tracking-widest"
+                className="block uppercase tracking-widest"
               >
                 Input
               </Text>
+              <TTSButton text={query} lang={srcLang || 'en'} />
+            </Flex>
               <TextArea
                 color={query.length === 0 ? "red" : undefined}
                 value={query}
@@ -582,14 +586,17 @@ export default function Home() {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
           >
-            <Text
-              size="1"
-              weight="bold"
-              color="gray"
-              className="mb-2 ml-1 block uppercase tracking-widest"
-            >
-              Result
-            </Text>
+            <Flex justify="between" align="center" className="mb-2 ml-1">
+              <Text
+                size="1"
+                weight="bold"
+                color="gray"
+                className="block uppercase tracking-widest"
+              >
+                Result
+              </Text>
+              <TTSButton text={result.result} lang={dstLang || 'en'} />
+            </Flex>
             <Card>
               {result.result ? (
                 <Box className="prose prose-sm dark:prose-invert max-w-none">


### PR DESCRIPTION
- Added `SpeakerIcon` and `TTSButton` components to `web/src/components.tsx`.
- Integrated `TTSButton` next to the "Input" and "Result" labels in `web/src/pages/Home.tsx`.
- The `TTSButton` uses the Google Translate TTS API `client=tw-ob` with a 200 character text slice limit to prevent URL length errors.

---
*PR created automatically by Jules for task [10795296220614717612](https://jules.google.com/task/10795296220614717612) started by @Asutorufa*