### PR TITLE
feat: add configurable prompt modes for AI translation

### DIFF
--- a/common/src/ai.rs
+++ b/common/src/ai.rs
@@ -107,14 +107,38 @@ impl Models {
     }
 }
 
-fn system_msg(chars_limit: bool) -> &'static str {
-    if chars_limit {
-        r#"You are a professional, authentic translation engine, only returns translations.
+fn system_msg(chars_limit: bool, mode: Option<&str>) -> &'static str {
+    match mode {
+        Some("translate") => {
+            r#"You are a professional, authentic translation engine.
+Your task is to provide ONLY the direct translation of the input text.
+Do not include any explanations, annotations, phonetic transcriptions, or conversational text.
+Just output the translated text."#
+        }
+        Some("explain") => {
+            r#"You are a professional, authentic translation engine.
+Your task is to provide the translation, followed by a brief, clear explanation of the key words, phrases, or grammar points used in the text.
+Help the user understand why the text was translated this way."#
+        }
+        Some("detailed") => {
+            r#"You are a professional language tutor and translation engine.
+Your task is to provide a highly detailed analysis of the input text.
+Include the following:
+1. The overall translation.
+2. The pronunciation (e.g., Romaji, Pinyin, or IPA if appropriate).
+3. A detailed, word-by-word breakdown of meaning and grammar.
+4. Explanations of any idioms, cultural nuances, or specific grammar patterns."#
+        }
+        _ => {
+            if chars_limit {
+                r#"You are a professional, authentic translation engine, only returns translations.
 - For words, phrases, or short sentences, provide the translation directly. Include essential explanations only if the context is ambiguous or the user explicitly requests it.
 - If the translated content is approaching the limit, prioritize preserving core meaning and compress the expression when necessary. Paraphrase or summarize if required.
 "#
-    } else {
-        r#"You are a professional, authentic translation engine, only returns translations."#
+            } else {
+                r#"You are a professional, authentic translation engine, only returns translations."#
+            }
+        }
     }
 }
 
@@ -130,6 +154,7 @@ pub struct TranslateRequest<'a> {
     pub query: &'a str,
     pub chars_limit: bool,
     pub instruction: Option<&'a str>,
+    pub prompt_mode: Option<&'a str>,
     pub dst_lang: Option<&'a str>,
 }
 
@@ -162,13 +187,14 @@ pub async fn translate<'a>(
         query: req.query,
         chars_limit: req.chars_limit,
         instruction: instruction.as_deref(),
+        prompt_mode: req.prompt_mode,
         dst_lang: req.dst_lang,
     };
 
     let messages = vec![
         hj_ai::Message {
             role: "system".to_string(),
-            content: system_msg(req2.chars_limit).to_string(),
+            content: system_msg(req2.chars_limit, req2.prompt_mode).to_string(),
         },
         hj_ai::Message {
             role: "user".to_string(),
@@ -203,7 +229,7 @@ pub async fn google_search_req<'a>(
     let messages = vec![
         hj_ai::Message {
             role: "system".to_string(),
-            content: system_msg(req.chars_limit).to_string(),
+            content: system_msg(req.chars_limit, req.prompt_mode).to_string(),
         },
         hj_ai::Message {
             role: "user".to_string(),
@@ -270,13 +296,14 @@ pub async fn translate_stream<'a>(
         query: req.query,
         chars_limit: req.chars_limit,
         instruction: instruction.as_deref(),
+        prompt_mode: req.prompt_mode,
         dst_lang: req.dst_lang,
     };
 
     let messages = vec![
         hj_ai::Message {
             role: "system".to_string(),
-            content: system_msg(req2.chars_limit).to_string(),
+            content: system_msg(req2.chars_limit, req2.prompt_mode).to_string(),
         },
         hj_ai::Message {
             role: "user".to_string(),
@@ -323,7 +350,7 @@ pub async fn google_search_req_stream<'a>(
     let messages = vec![
         hj_ai::Message {
             role: "system".to_string(),
-            content: system_msg(req.chars_limit).to_string(),
+            content: system_msg(req.chars_limit, req.prompt_mode).to_string(),
         },
         hj_ai::Message {
             role: "user".to_string(),

--- a/common/src/ai.rs
+++ b/common/src/ai.rs
@@ -107,22 +107,8 @@ impl Models {
     }
 }
 
-enum PromptMode {
-    Translate,
-    Explain,
-    Detailed,
-    Default,
-}
-
-fn system_msg(chars_limit: bool, mode: Option<&str>) -> &'static str {
-    let mode = match mode {
-        Some("translate") => PromptMode::Translate,
-        Some("explain") => PromptMode::Explain,
-        Some("detailed") => PromptMode::Detailed,
-        _ => PromptMode::Default,
-    };
-
-    match mode {
+fn system_msg(chars_limit: bool, mode: Option<PromptMode>) -> &'static str {
+    match mode.unwrap_or(PromptMode::Default) {
         PromptMode::Translate => {
             r#"You are a professional, authentic translation engine.
 Your task is to provide ONLY the direct translation of the input text.
@@ -162,13 +148,23 @@ pub struct Response {
     pub reasoning: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PromptMode {
+    Translate,
+    Explain,
+    Detailed,
+    #[default]
+    Default,
+}
+
 #[derive(Debug, Default)]
 pub struct TranslateRequest<'a> {
     pub model: &'a str,
     pub query: &'a str,
     pub chars_limit: bool,
     pub instruction: Option<&'a str>,
-    pub prompt_mode: Option<&'a str>,
+    pub prompt_mode: Option<PromptMode>,
     pub dst_lang: Option<&'a str>,
 }
 

--- a/common/src/ai.rs
+++ b/common/src/ai.rs
@@ -107,20 +107,34 @@ impl Models {
     }
 }
 
+enum PromptMode {
+    Translate,
+    Explain,
+    Detailed,
+    Default,
+}
+
 fn system_msg(chars_limit: bool, mode: Option<&str>) -> &'static str {
+    let mode = match mode {
+        Some("translate") => PromptMode::Translate,
+        Some("explain") => PromptMode::Explain,
+        Some("detailed") => PromptMode::Detailed,
+        _ => PromptMode::Default,
+    };
+
     match mode {
-        Some("translate") => {
+        PromptMode::Translate => {
             r#"You are a professional, authentic translation engine.
 Your task is to provide ONLY the direct translation of the input text.
 Do not include any explanations, annotations, phonetic transcriptions, or conversational text.
 Just output the translated text."#
         }
-        Some("explain") => {
+        PromptMode::Explain => {
             r#"You are a professional, authentic translation engine.
 Your task is to provide the translation, followed by a brief, clear explanation of the key words, phrases, or grammar points used in the text.
 Help the user understand why the text was translated this way."#
         }
-        Some("detailed") => {
+        PromptMode::Detailed => {
             r#"You are a professional language tutor and translation engine.
 Your task is to provide a highly detailed analysis of the input text.
 Include the following:
@@ -129,7 +143,7 @@ Include the following:
 3. A detailed, word-by-word breakdown of meaning and grammar.
 4. Explanations of any idioms, cultural nuances, or specific grammar patterns."#
         }
-        _ => {
+        PromptMode::Default => {
             if chars_limit {
                 r#"You are a professional, authentic translation engine, only returns translations.
 - For words, phrases, or short sentences, provide the translation directly. Include essential explanations only if the context is ambiguous or the user explicitly requests it.

--- a/common/src/route.rs
+++ b/common/src/route.rs
@@ -66,7 +66,7 @@ pub struct WordQueryRequest {
     pub word: String,
     pub custom_llm: Option<CustomLLM>,
     pub instruction: Option<String>,
-    pub prompt_mode: Option<String>,
+    pub prompt_mode: Option<crate::ai::PromptMode>,
     pub google_search: Option<bool>,
     pub src_lang: Option<String>,
     pub dst_lang: Option<String>,
@@ -654,7 +654,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                     chars_limit: false,
                                     query: &req.word,
                                     instruction: req.instruction().as_deref(),
-                                    prompt_mode: req.prompt_mode.as_deref(),
+                                    prompt_mode: req.prompt_mode,
                                     dst_lang: req.dst_lang.as_deref(),
                                 },
                             )
@@ -673,7 +673,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                     chars_limit: false,
                                     query: &req.word,
                                     instruction: req.instruction().as_deref(),
-                                    prompt_mode: req.prompt_mode.as_deref(),
+                                    prompt_mode: req.prompt_mode,
                                     dst_lang: req.dst_lang.as_deref(),
                                 },
                             )
@@ -797,7 +797,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                 chars_limit: false,
                                 query: &req.word,
                                 instruction: req.instruction().as_deref(),
-                                prompt_mode: req.prompt_mode.as_deref(),
+                                prompt_mode: req.prompt_mode,
                                 dst_lang: req.dst_lang.as_deref(),
                             },
                         )
@@ -814,7 +814,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                 chars_limit: false,
                                 query: &req.word,
                                 instruction: req.instruction().as_deref(),
-                                prompt_mode: req.prompt_mode.as_deref(),
+                                prompt_mode: req.prompt_mode,
                                 dst_lang: req.dst_lang.as_deref(),
                             },
                         )

--- a/common/src/route.rs
+++ b/common/src/route.rs
@@ -66,6 +66,7 @@ pub struct WordQueryRequest {
     pub word: String,
     pub custom_llm: Option<CustomLLM>,
     pub instruction: Option<String>,
+    pub prompt_mode: Option<String>,
     pub google_search: Option<bool>,
     pub src_lang: Option<String>,
     pub dst_lang: Option<String>,
@@ -653,6 +654,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                     chars_limit: false,
                                     query: &req.word,
                                     instruction: req.instruction().as_deref(),
+                                    prompt_mode: req.prompt_mode.as_deref(),
                                     dst_lang: req.dst_lang.as_deref(),
                                 },
                             )
@@ -671,6 +673,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                     chars_limit: false,
                                     query: &req.word,
                                     instruction: req.instruction().as_deref(),
+                                    prompt_mode: req.prompt_mode.as_deref(),
                                     dst_lang: req.dst_lang.as_deref(),
                                 },
                             )
@@ -794,6 +797,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                 chars_limit: false,
                                 query: &req.word,
                                 instruction: req.instruction().as_deref(),
+                                prompt_mode: req.prompt_mode.as_deref(),
                                 dst_lang: req.dst_lang.as_deref(),
                             },
                         )
@@ -810,6 +814,7 @@ impl<T1: DatabaseExecutor, T2: Translator> RunOpt<T1, T2> {
                                 chars_limit: false,
                                 query: &req.word,
                                 instruction: req.instruction().as_deref(),
+                                prompt_mode: req.prompt_mode.as_deref(),
                                 dst_lang: req.dst_lang.as_deref(),
                             },
                         )

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -28,6 +28,7 @@ async function fetchTranslation(
     selected: string;
     query: string;
     instruction: string;
+    prompt_mode?: string;
     google_search: boolean;
     srcLang: string;
     dstLang: string;
@@ -47,6 +48,7 @@ async function fetchTranslation(
       method: opts.selected,
       word: opts.query,
       instruction: opts.instruction.length > 0 ? opts.instruction : undefined,
+      prompt_mode: opts.prompt_mode !== "default" ? opts.prompt_mode : undefined,
       google_search: opts.google_search,
       src_lang: opts.srcLang ? opts.srcLang : undefined,
       dst_lang: opts.dstLang ? opts.dstLang : undefined,
@@ -136,6 +138,7 @@ export default function Home() {
   const [dstLang, setDstLang] = useLocalStorage("dst_lang", "ja");
   const [loading, setLoading] = useState(false);
   const [stream, setStream] = useLocalStorage("stream", true);
+  const [promptMode, setPromptMode] = useLocalStorage("prompt_mode", "default");
   const [open, setOpen] = useState(false);
   const [showAdvanced, setShowAdvanced] = useLocalStorage(
     "home_advanced_open",
@@ -188,6 +191,7 @@ export default function Home() {
             method: modelName,
             word: query,
             instruction: instruction.length > 0 ? instruction : undefined,
+            prompt_mode: promptMode !== "default" ? promptMode : undefined,
             google_search: googleSearch,
             src_lang: srcLang ? srcLang : undefined,
             dst_lang: dstLang ? dstLang : undefined,
@@ -223,6 +227,7 @@ export default function Home() {
           dstLang: dstLang,
           google_search: googleSearch,
           instruction: instruction,
+          prompt_mode: promptMode,
           selected: modelName,
           custom_llm: customLLM,
         },
@@ -245,6 +250,7 @@ export default function Home() {
     dstLang,
     googleSearch,
     instruction,
+    promptMode,
     selected,
     customModels,
     setResult,
@@ -504,7 +510,7 @@ export default function Home() {
                   transition={{ duration: 0.25 }}
                   className="mt-4 space-y-4 overflow-hidden"
                 >
-                  <Flex gap="6" wrap="wrap">
+                  <Flex gap="6" wrap="wrap" align="center">
                     <Text as="label" size="2" weight="medium">
                       <Flex gap="2" align="center" className="cursor-pointer">
                         <Switch
@@ -525,6 +531,42 @@ export default function Home() {
                       </Flex>
                     </Text>
                   </Flex>
+
+                  <Box>
+                    <Text
+                      as="label"
+                      size="1"
+                      weight="bold"
+                      color="gray"
+                      className="mb-2 block uppercase tracking-widest"
+                    >
+                      Prompt Mode
+                    </Text>
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger>
+                        <Button variant="surface" color="gray" className="cursor-pointer">
+                          {promptMode === "translate" && "Simple Translation"}
+                          {promptMode === "explain" && "Word-by-Word Explanation"}
+                          {promptMode === "detailed" && "Detailed Analysis"}
+                          {promptMode === "default" && "Default"}
+                        </Button>
+                      </DropdownMenu.Trigger>
+                      <DropdownMenu.Content>
+                        <DropdownMenu.Item onSelect={() => setPromptMode("default")}>
+                          Default
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item onSelect={() => setPromptMode("translate")}>
+                          Simple Translation
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item onSelect={() => setPromptMode("explain")}>
+                          Word-by-Word Explanation
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item onSelect={() => setPromptMode("detailed")}>
+                          Detailed Analysis
+                        </DropdownMenu.Item>
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Root>
+                  </Box>
 
                   {!googleSearch && (
                     <Box>

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -28,7 +28,7 @@ async function fetchTranslation(
     selected: string;
     query: string;
     instruction: string;
-    prompt_mode?: string;
+    prompt_mode?: "translate" | "explain" | "detailed" | "default";
     google_search: boolean;
     srcLang: string;
     dstLang: string;
@@ -139,7 +139,7 @@ export default function Home() {
   const [dstLang, setDstLang] = useLocalStorage("dst_lang", "ja");
   const [loading, setLoading] = useState(false);
   const [stream, setStream] = useLocalStorage("stream", true);
-  const [promptMode, setPromptMode] = useLocalStorage("prompt_mode", "default");
+  const [promptMode, setPromptMode] = useLocalStorage<"translate" | "explain" | "detailed" | "default">("prompt_mode", "default");
   const [open, setOpen] = useState(false);
   const [showAdvanced, setShowAdvanced] = useLocalStorage(
     "home_advanced_open",

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -150,7 +150,9 @@ export default function Home() {
   const [dstLang, setDstLang] = useLocalStorage("dst_lang", "ja");
   const [loading, setLoading] = useState(false);
   const [stream, setStream] = useLocalStorage("stream", true);
-  const [promptMode, setPromptMode] = useLocalStorage<"translate" | "explain" | "detailed" | "default">("prompt_mode", "default");
+  const [promptMode, setPromptMode] = useLocalStorage<
+    "translate" | "explain" | "detailed" | "default"
+  >("prompt_mode", "default");
   const [open, setOpen] = useState(false);
   const [showAdvanced, setShowAdvanced] = useLocalStorage(
     "home_advanced_open",

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -118,6 +118,17 @@ const translationMap = Object.fromEntries(
   [...translationSources, ...dictSources].map(({ key, name }) => [key, name]),
 ) as Record<(typeof translationSources)[number]["key"], string>;
 
+const promptModes = [
+  { key: "default", label: "Default" },
+  { key: "translate", label: "Simple Translation" },
+  { key: "explain", label: "Word-by-Word Explanation" },
+  { key: "detailed", label: "Detailed Analysis" },
+] as const;
+
+const promptModeLabels = Object.fromEntries(
+  promptModes.map((m) => [m.key, m.label]),
+) as Record<(typeof promptModes)[number]["key"], string>;
+
 const itemVariants = {
   hidden: { opacity: 0, y: 10 },
   visible: { opacity: 1, y: 0 },
@@ -550,34 +561,18 @@ export default function Home() {
                           color="gray"
                           className="cursor-pointer"
                         >
-                          {promptMode === "translate" && "Simple Translation"}
-                          {promptMode === "explain" &&
-                            "Word-by-Word Explanation"}
-                          {promptMode === "detailed" && "Detailed Analysis"}
-                          {promptMode === "default" && "Default"}
+                          {promptModeLabels[promptMode]}
                         </Button>
                       </DropdownMenu.Trigger>
                       <DropdownMenu.Content>
-                        <DropdownMenu.Item
-                          onSelect={() => setPromptMode("default")}
-                        >
-                          Default
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                          onSelect={() => setPromptMode("translate")}
-                        >
-                          Simple Translation
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                          onSelect={() => setPromptMode("explain")}
-                        >
-                          Word-by-Word Explanation
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                          onSelect={() => setPromptMode("detailed")}
-                        >
-                          Detailed Analysis
-                        </DropdownMenu.Item>
+                        {promptModes.map((mode) => (
+                          <DropdownMenu.Item
+                            key={mode.key}
+                            onSelect={() => setPromptMode(mode.key)}
+                          >
+                            {mode.label}
+                          </DropdownMenu.Item>
+                        ))}
                       </DropdownMenu.Content>
                     </DropdownMenu.Root>
                   </Box>

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -48,7 +48,8 @@ async function fetchTranslation(
       method: opts.selected,
       word: opts.query,
       instruction: opts.instruction.length > 0 ? opts.instruction : undefined,
-      prompt_mode: opts.prompt_mode !== "default" ? opts.prompt_mode : undefined,
+      prompt_mode:
+        opts.prompt_mode !== "default" ? opts.prompt_mode : undefined,
       google_search: opts.google_search,
       src_lang: opts.srcLang ? opts.srcLang : undefined,
       dst_lang: opts.dstLang ? opts.dstLang : undefined,
@@ -544,24 +545,37 @@ export default function Home() {
                     </Text>
                     <DropdownMenu.Root>
                       <DropdownMenu.Trigger>
-                        <Button variant="surface" color="gray" className="cursor-pointer">
+                        <Button
+                          variant="surface"
+                          color="gray"
+                          className="cursor-pointer"
+                        >
                           {promptMode === "translate" && "Simple Translation"}
-                          {promptMode === "explain" && "Word-by-Word Explanation"}
+                          {promptMode === "explain" &&
+                            "Word-by-Word Explanation"}
                           {promptMode === "detailed" && "Detailed Analysis"}
                           {promptMode === "default" && "Default"}
                         </Button>
                       </DropdownMenu.Trigger>
                       <DropdownMenu.Content>
-                        <DropdownMenu.Item onSelect={() => setPromptMode("default")}>
+                        <DropdownMenu.Item
+                          onSelect={() => setPromptMode("default")}
+                        >
                           Default
                         </DropdownMenu.Item>
-                        <DropdownMenu.Item onSelect={() => setPromptMode("translate")}>
+                        <DropdownMenu.Item
+                          onSelect={() => setPromptMode("translate")}
+                        >
                           Simple Translation
                         </DropdownMenu.Item>
-                        <DropdownMenu.Item onSelect={() => setPromptMode("explain")}>
+                        <DropdownMenu.Item
+                          onSelect={() => setPromptMode("explain")}
+                        >
                           Word-by-Word Explanation
                         </DropdownMenu.Item>
-                        <DropdownMenu.Item onSelect={() => setPromptMode("detailed")}>
+                        <DropdownMenu.Item
+                          onSelect={() => setPromptMode("detailed")}
+                        >
                           Detailed Analysis
                         </DropdownMenu.Item>
                       </DropdownMenu.Content>


### PR DESCRIPTION
This PR introduces a configurable 'Prompt Mode' for AI-based translations, addressing the issue where a static system prompt is insufficient for various user needs. 

It provides four modes:
- Default: The previous behavior.
- Simple Translation: Just the translation without extra text.
- Word-by-Word Explanation: A translation with brief explanations of the key words/grammar.
- Detailed Analysis: A highly detailed breakdown including pronunciation, grammar, and idioms.

Users can select their desired mode from a new dropdown in the Advanced section of the Home UI when using custom LLMs.

---
*PR created automatically by Jules for task [13748945635416351451](https://jules.google.com/task/13748945635416351451) started by @Asutorufa*