### PR TITLE
Support Gemma 4 reasoning on Cloudflare Workers AI

### DIFF
--- a/ai/src/sse.rs
+++ b/ai/src/sse.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 struct StreamCompletionResponse {
     response: Option<String>,
     choices: Option<Vec<Choice>>,
+    thought: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -17,6 +18,7 @@ struct Choice {
 struct Delta {
     content: Option<String>,
     reasoning_content: Option<String>,
+    thought: Option<String>,
 }
 
 pub fn parse_stream<S, E>(
@@ -47,7 +49,7 @@ where
                             match serde_json::from_str::<StreamCompletionResponse>(&data) {
                                 Ok(response) => {
                                     let mut content = response.response.unwrap_or_default();
-                                    let mut thinking = None;
+                                    let mut thinking = response.thought;
 
                                     if let Some(choice) =
                                         response.choices.and_then(|c| c.into_iter().next())
@@ -55,8 +57,14 @@ where
                                         if let Some(c) = choice.delta.content {
                                             content.push_str(&c);
                                         }
-                                        if let Some(t) = choice.delta.reasoning_content {
-                                            thinking = Some(t);
+                                        if let Some(t) =
+                                            choice.delta.reasoning_content.or(choice.delta.thought)
+                                        {
+                                            if thinking.is_none() {
+                                                thinking = Some(t);
+                                            } else if let Some(think) = thinking.as_mut() {
+                                                think.push_str(&t);
+                                            }
                                         }
                                     }
 
@@ -229,5 +237,34 @@ mod tests {
             results[1].as_ref().unwrap().thinking,
             Some("Thinking...".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_parse_stream_thought_format() {
+        let chunks = vec![
+            Ok::<_, std::io::Error>(Bytes::from("data: {\"thought\": \"Initial thought\"}\n\n")),
+            Ok::<_, std::io::Error>(Bytes::from(
+                "data: {\"choices\": [{\"delta\": {\"thought\": \" more thought\"}}]}\n\n",
+            )),
+            Ok::<_, std::io::Error>(Bytes::from(
+                "data: {\"choices\": [{\"delta\": {\"content\": \"Result content\"}}]}\n\n",
+            )),
+        ];
+
+        let mock_stream = stream::iter(chunks);
+        let parsed_stream = parse_stream(mock_stream);
+
+        let results: Vec<_> = parsed_stream.collect().await;
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(
+            results[0].as_ref().unwrap().thinking,
+            Some("Initial thought".to_string())
+        );
+        assert_eq!(
+            results[1].as_ref().unwrap().thinking,
+            Some(" more thought".to_string())
+        );
+        assert_eq!(results[2].as_ref().unwrap().content, "Result content");
     }
 }

--- a/ai/src/sse.rs
+++ b/ai/src/sse.rs
@@ -7,6 +7,7 @@ struct StreamCompletionResponse {
     response: Option<String>,
     choices: Option<Vec<Choice>>,
     thought: Option<String>,
+    reasoning: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -19,6 +20,7 @@ struct Delta {
     content: Option<String>,
     reasoning_content: Option<String>,
     thought: Option<String>,
+    reasoning: Option<String>,
 }
 
 pub fn parse_stream<S, E>(
@@ -49,7 +51,7 @@ where
                             match serde_json::from_str::<StreamCompletionResponse>(&data) {
                                 Ok(response) => {
                                     let mut content = response.response.unwrap_or_default();
-                                    let mut thinking = response.thought;
+                                    let mut thinking = response.thought.or(response.reasoning);
 
                                     if let Some(choice) =
                                         response.choices.and_then(|c| c.into_iter().next())
@@ -57,8 +59,11 @@ where
                                         if let Some(c) = choice.delta.content {
                                             content.push_str(&c);
                                         }
-                                        if let Some(t) =
-                                            choice.delta.reasoning_content.or(choice.delta.thought)
+                                        if let Some(t) = choice
+                                            .delta
+                                            .reasoning_content
+                                            .or(choice.delta.reasoning)
+                                            .or(choice.delta.thought)
                                         {
                                             if thinking.is_none() {
                                                 thinking = Some(t);
@@ -247,6 +252,9 @@ mod tests {
                 "data: {\"choices\": [{\"delta\": {\"thought\": \" more thought\"}}]}\n\n",
             )),
             Ok::<_, std::io::Error>(Bytes::from(
+                "data: {\"choices\": [{\"delta\": {\"reasoning\": \" even more\"}}]}\n\n",
+            )),
+            Ok::<_, std::io::Error>(Bytes::from(
                 "data: {\"choices\": [{\"delta\": {\"content\": \"Result content\"}}]}\n\n",
             )),
         ];
@@ -256,7 +264,7 @@ mod tests {
 
         let results: Vec<_> = parsed_stream.collect().await;
 
-        assert_eq!(results.len(), 3);
+        assert_eq!(results.len(), 4);
         assert_eq!(
             results[0].as_ref().unwrap().thinking,
             Some("Initial thought".to_string())
@@ -265,6 +273,10 @@ mod tests {
             results[1].as_ref().unwrap().thinking,
             Some(" more thought".to_string())
         );
-        assert_eq!(results[2].as_ref().unwrap().content, "Result content");
+        assert_eq!(
+            results[2].as_ref().unwrap().thinking,
+            Some(" even more".to_string())
+        );
+        assert_eq!(results[3].as_ref().unwrap().content, "Result content");
     }
 }

--- a/ai/src/workers.rs
+++ b/ai/src/workers.rs
@@ -55,12 +55,37 @@ struct AiRequest {
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chat_template_kwargs: Option<ChatTemplateKwargs>,
+}
+
+#[cfg(feature = "worker")]
+#[derive(Serialize)]
+struct ChatTemplateKwargs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_thinking: Option<bool>,
 }
 
 #[cfg(feature = "worker")]
 #[derive(Deserialize)]
 struct AiResponse {
-    response: String,
+    response: Option<String>,
+    #[serde(default)]
+    choices: Vec<Choice>,
+    thought: Option<String>,
+}
+
+#[cfg(feature = "worker")]
+#[derive(Deserialize)]
+struct Choice {
+    message: ChoiceMessage,
+}
+
+#[cfg(feature = "worker")]
+#[derive(Deserialize)]
+struct ChoiceMessage {
+    content: String,
+    reasoning_content: Option<String>,
 }
 
 impl Completion for WorkersAI {
@@ -74,16 +99,26 @@ impl Completion for WorkersAI {
                     stream: false,
                     max_tokens: 4096,
                     reasoning_effort: self.reasoning_effort.clone(),
+                    chat_template_kwargs: Some(ChatTemplateKwargs {
+                        enable_thinking: Some(true),
+                    }),
                 };
                 let res: AiResponse = ai
                     .run(&self.model, req)
                     .await
                     .map_err(|e| Error::Internal(e.to_string()))?;
 
-                return Ok(CompletionResponse {
-                    content: res.response,
-                    thinking: None,
-                });
+                let mut thinking = res.thought;
+                let mut content = res.response.unwrap_or_default();
+
+                if let Some(choice) = res.choices.first() {
+                    content = choice.message.content.clone();
+                    if thinking.is_none() {
+                        thinking = choice.message.reasoning_content.clone();
+                    }
+                }
+
+                return Ok(CompletionResponse { content, thinking });
             }
         }
 
@@ -105,6 +140,9 @@ impl Completion for WorkersAI {
                     stream: true,
                     max_tokens: 4096,
                     reasoning_effort: self.reasoning_effort.clone(),
+                    chat_template_kwargs: Some(ChatTemplateKwargs {
+                        enable_thinking: Some(true),
+                    }),
                 };
                 let stream = ai
                     .run_bytes(&self.model, req)

--- a/ai/src/workers.rs
+++ b/ai/src/workers.rs
@@ -73,6 +73,7 @@ struct AiResponse {
     #[serde(default)]
     choices: Vec<Choice>,
     thought: Option<String>,
+    reasoning: Option<String>,
 }
 
 #[cfg(feature = "worker")]
@@ -86,6 +87,7 @@ struct Choice {
 struct ChoiceMessage {
     content: String,
     reasoning_content: Option<String>,
+    reasoning: Option<String>,
 }
 
 impl Completion for WorkersAI {
@@ -108,13 +110,17 @@ impl Completion for WorkersAI {
                     .await
                     .map_err(|e| Error::Internal(e.to_string()))?;
 
-                let mut thinking = res.thought;
+                let mut thinking = res.thought.or(res.reasoning);
                 let mut content = res.response.unwrap_or_default();
 
                 if let Some(choice) = res.choices.first() {
                     content = choice.message.content.clone();
                     if thinking.is_none() {
-                        thinking = choice.message.reasoning_content.clone();
+                        thinking = choice
+                            .message
+                            .reasoning_content
+                            .clone()
+                            .or(choice.message.reasoning.clone());
                     }
                 }
 

--- a/common/src/ai.rs
+++ b/common/src/ai.rs
@@ -120,6 +120,7 @@ async fn google_search(
 #[derive(Clone, Copy, Debug)]
 pub enum Models {
     Gemma3_12bIt,
+    Gemma4_26bA4bIt,
     Llama4Scout17B16EInstruct,
     DeepSeekR1DistillQwen32b,
     GPTOss20B,
@@ -135,6 +136,7 @@ impl Models {
     pub fn as_str(&self) -> &str {
         match self {
             Models::Gemma3_12bIt => "@cf/google/gemma-3-12b-it",
+            Models::Gemma4_26bA4bIt => "@cf/google/gemma-4-26b-a4b-it",
             Models::Llama4Scout17B16EInstruct => "@cf/meta/llama-3.1-8b-instruct", // mapping placeholder
             Models::DeepSeekR1DistillQwen32b => "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
             Models::GPTOss20B => "gpt-oss-20b",
@@ -144,6 +146,7 @@ impl Models {
     pub fn from_model_name(model_name: &str) -> Option<Self> {
         match model_name {
             "@cf/google/gemma-3-12b-it" => Some(Models::Gemma3_12bIt),
+            "@cf/google/gemma-4-26b-a4b-it" => Some(Models::Gemma4_26bA4bIt),
             "@cf/meta/llama-3.1-8b-instruct" => Some(Models::Llama4Scout17B16EInstruct),
             "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b" => {
                 Some(Models::DeepSeekR1DistillQwen32b)
@@ -156,6 +159,7 @@ impl Models {
     pub fn llms() -> Vec<String> {
         vec![
             Models::Gemma3_12bIt.to_string(),
+            Models::Gemma4_26bA4bIt.to_string(),
             Models::Llama4Scout17B16EInstruct.to_string(),
             Models::DeepSeekR1DistillQwen32b.to_string(),
             Models::GPTOss20B.to_string(),


### PR DESCRIPTION
This PR implements support for the `gemma-4-26b-a4b-it` model on Cloudflare Workers AI, specifically focusing on its reasoning (thinking) capabilities.

🎯 **What**
- Added the new Gemma 4 model to the supported AI models.
- Updated the Cloudflare Workers AI request payload to explicitly enable thinking mode.
- Enhanced response parsing for both non-streaming and streaming responses to capture reasoning output from `thought` and `reasoning_content` fields.

💡 **Why**
Reasoning models like Gemma 4 and DeepSeek R1 provide valuable step-by-step thinking processes that improve response accuracy and help users understand the model's logic. This integration ensures these thoughts are correctly captured and surfaced in the application.

✅ **Verification**
- Ran `cargo check -p hj_ai` and `cargo check -p hjcommon`.
- Ran unit tests in `hj_ai` (including a new test for streaming thinking output) and `hjcommon`. All tests passed.
- Verified request/response structures against Cloudflare Workers AI documentation.

✨ **Result**
Users can now select and use `@cf/google/gemma-4-26b-a4b-it` (and other reasoning models) through Workers AI, with full support for displaying their thinking process.

---
*PR created automatically by Jules for task [10344715231270192024](https://jules.google.com/task/10344715231270192024) started by @Asutorufa*